### PR TITLE
refactor: unify forge & smelter, improve draw date logic, and fix data/UX bugs

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -8,7 +8,7 @@ import 'package:provider/provider.dart';
 
 // --- Project-Specific Screen Imports ---
 // Import the various screens used within the application.
-import 'golden_ticket/the_forge_screen.dart';   // Screen for forging tickets.
+import 'golden_ticket/the_smelter.dart';   // Screen for forging tickets.
 import 'golden_ticket/auth/auth_state.dart';     // Authentication state management class.
 import 'golden_ticket/main_screen.dart';         // The main screen shown after sign-in or as default.
 import 'settings/settings_controller.dart';      // Controller for managing app settings (like theme).
@@ -110,14 +110,14 @@ class MyApp extends StatelessWidget {
                     case Routes.gameSelector:
                     // Navigate to the Game Selector screen.
                       return const GameSelectorScreen();
-                    case Routes.theForge:
+                    case Routes.forge:
                     // Navigate to The Forge screen.
                     // Arguments ('gameName', 'nextDrawDate') are expected to be passed via routeSettings.arguments
                     // and are handled internally within TheForgeScreen's initState/didChangeDependencies.
-                      return const TheForgeScreen();
+                     // return const TheForgeScreen();
                     case Routes.theSmelter:
                     // Navigate to The Smelter screen.
-                      return const TheSmelter();
+                      return const SmelterScreen();
                     case Routes.verifyResults:
                     // Navigate to the Verify Results screen (purpose might be specific/future).
                       return const VerifyResultsScreen();

--- a/lib/src/golden_ticket/create_account_screen.dart
+++ b/lib/src/golden_ticket/create_account_screen.dart
@@ -1,25 +1,14 @@
 import 'package:flutter/material.dart';
-// Import the http package for making API calls.
 import 'package:http/http.dart' as http;
-// Import dart:convert for JSON encoding/decoding.
 import 'dart:convert';
-// Import logging framework.
 import 'package:logging/logging.dart';
-// Import url_launcher for opening external URLs (like email verification links).
 import 'package:url_launcher/url_launcher.dart';
 
-
 // --- Project-Specific Imports ---
-// Import utility for setting up loggers.
 import 'logging_utils.dart';
-// Import the screen used for selecting a game event.
 import 'game_selector_screen.dart';
-
-
-// DatabaseHelper import is currently commented out (DB setup moved to sign-in).
-// import 'database_helper.dart';
-// AuthState import is currently commented out (not directly needed for account creation logic here).
-// import 'auth/auth_state.dart';
+// Import the DatabaseHelper for profile/game activation logic
+import 'database_helper.dart';
 
 /// A StatefulWidget representing the Create Account screen.
 /// Collects user details for registration.
@@ -36,46 +25,29 @@ class CreateAccountScreen extends StatefulWidget {
 /// The State class for the CreateAccountScreen widget.
 /// Manages the form state, input controllers, and account creation process.
 class CreateAccountScreenState extends State<CreateAccountScreen> {
-  // Logger for this specific screen.
   final _log = Logger('CreateAccountScreen');
-  // GlobalKey to manage the Form state and validation.
   final _formKey = GlobalKey<FormState>();
-  // Text editing controllers for each input field.
   final _usernameController = TextEditingController();
   final _passwordController = TextEditingController();
   final _emailController = TextEditingController();
-  final _firstNameController = TextEditingController();
-  final _lastNameController = TextEditingController();
 
   // State variable to store the name of the game event selected by the user.
-  // Starts as null; selection is mandatory before creating the account.
   String? _selectedGameEvent;
-  // Flag to indicate if an account creation API call is in progress.
-  // Used to disable the button and show a loading indicator.
   bool _isCreatingAccount = false;
 
   @override
   void initState() {
     super.initState();
-    // Configure the logger for this screen.
     LoggingUtils.setupLogger(_log);
-    // Initial game selection is no longer pre-filled; user must explicitly select.
   }
 
   /// Navigates to the GameSelectorScreen to allow the user to pick a game event.
-  /// Updates the state with the selected game name upon return.
   Future<void> _selectGameEvent() async {
-    // Navigate to the GameSelectorScreen using its defined route name.
-    // `await` pauses execution until the GameSelectorScreen is popped.
     final result = await Navigator.pushNamed(
       context,
       GameSelectorScreen.routeName,
     );
-
-    // Check if a result was returned (i.e., the user confirmed a selection)
-    // and if the result is of the expected type (String).
     if (result != null && result is String) {
-      // Update the state to store the selected game event name.
       setState(() {
         _selectedGameEvent = result;
       });
@@ -85,100 +57,88 @@ class CreateAccountScreenState extends State<CreateAccountScreen> {
     }
   }
 
-
   /// Handles the account creation process:
   /// 1. Validates the form and checks for game selection.
   /// 2. Makes an API call to the /register endpoint.
-  /// 3. Handles the API response (success or failure).
-  /// 4. Navigates back or shows errors accordingly.
-  /// 5. Handles optional email verification link launching.
+  /// 3. On success, creates a local user profile and adds the selected game as active.
+  /// 4. Handles errors and verification.
   Future<void> _createAccount() async {
-    // --- Validation Step 1: Check if a game has been selected ---
     if (_selectedGameEvent == null) {
-      _showSnackBar('Please select a preferred game.'); // Show error if no game selected.
-      return; // Stop the process.
+      _showSnackBar('Please select a preferred game.');
+      return;
     }
-    // --- End Validation Step 1 ---
-
-    // --- Validation Step 2: Validate the form fields ---
-    // Also check if an account creation process is already running.
     if (_formKey.currentState!.validate() && !_isCreatingAccount) {
-      // Set the flag to indicate process start (disables button, shows loading).
       setState(() {
         _isCreatingAccount = true;
       });
 
-      // Define the API endpoint for registration.
       final url = Uri.https('governance.page', '/wp-json/apigold/v1/register');
-
-      // Store username for potential use after success (e.g., passing back to sign-in).
       final username = _usernameController.text.trim();
+      final email = _emailController.text.trim();
 
       try {
-        // Prepare the request body with user input, trimming whitespace.
         final body = {
           'username': username,
           'password': _passwordController.text,
-          'email': _emailController.text.trim(),
-          'first_name': _firstNameController.text.trim(),
-          'last_name': _lastNameController.text.trim(),
-          // Optionally include 'preferred_game': _selectedGameEvent if the API requires it.
+          'email': email,
+          'preferred_game': _selectedGameEvent,
         };
 
         _log.fine("Request Body (before encoding): $body");
 
-        // Make the POST request to the registration API.
         final response = await http.post(
           url,
-          headers: { 'Content-Type': 'application/json' }, // Set content type header.
-          body: json.encode(body), // Encode the body map as a JSON string.
+          headers: {'Content-Type': 'application/json'},
+          body: json.encode(body),
         );
 
         _log.info("Request Body (sent): ${json.encode(body)}");
         _log.info("Response Status Code: ${response.statusCode}");
         _log.info("Response Body: ${response.body}");
 
-        // After await, check if the widget is still mounted.
         if (!mounted) return;
 
-        // Decode the JSON response from the API.
         final responseData = json.decode(response.body);
-        // Extract the message from the response, providing a default error message.
         final responseMessage = responseData['message'] ?? 'An error occurred.';
 
-        // Check for successful account creation (HTTP 200 and 'status' == 'success').
+        // Successful account creation
         if (response.statusCode == 200 && responseData['status'] == 'success') {
           _log.info('Account creation successful (API status: success). Message: $responseMessage');
-          _showSnackBar(responseMessage); // Show the success message from the server.
+          _showSnackBar(responseMessage);
 
-          // Navigate back to the previous screen (likely SignInScreen), passing the created username.
-          // Note: SignInScreen's prefill logic using this username was removed, but pop still occurs.
+          // --- NEW: Create local profile and activate selected game ---
+          // 1. Extract the user_id from the response if available.
+          final userId = int.tryParse(responseData['user_id']?.toString() ?? '');
+          if (userId != null) {
+            // Create a minimal user profile in the local DB
+            await DatabaseHelper().insertOrUpdateUserProfile(userId: userId);
+            // Activate the selected game for this user in local DB
+            await DatabaseHelper().activateGameForUser(userId, _selectedGameEvent!);
+          } else {
+            _log.warning('No user_id received from API; skipping local profile creation.');
+          }
+          // --- END NEW ---
+
           Navigator.pop(context, username);
 
-          // Check if the response includes an email verification URL.
+          // Check for email verification URL
           final verificationUrl = responseData['data']?['verification_url'];
           if (verificationUrl != null && verificationUrl is String) {
-            // If a URL is provided, attempt to launch it.
             _launchVerificationUrl(verificationUrl);
           }
-
         } else {
-          // Handle account creation failure (non-200 status or 'status' != 'success').
           _log.warning('Account creation failed. Status: ${response.statusCode}, Body: ${response.body}');
-          _showSnackBar(responseMessage); // Show the error message from the server.
+          _showSnackBar(responseMessage);
         }
-
-      } catch (e, stacktrace) { // Catch any exceptions during the process.
-        _log.severe('Error during account creation process: $e', e, stacktrace); // Log error and stacktrace.
+      } catch (e, stacktrace) {
+        _log.severe('Error during account creation process: $e', e, stacktrace);
         if (mounted) {
           _showSnackBar('An unexpected error occurred during account creation.');
         }
       } finally {
-        // This block executes whether the try block succeeded or failed.
-        // Ensure the loading state is reset.
-        if(mounted) {
+        if (mounted) {
           setState(() {
-            _isCreatingAccount = false; // Re-enable the button.
+            _isCreatingAccount = false;
           });
         }
       }
@@ -187,23 +147,28 @@ class CreateAccountScreenState extends State<CreateAccountScreen> {
 
   /// Helper function to display a SnackBar message.
   void _showSnackBar(String text) {
-    if (mounted) { // Check if the widget is still in the tree.
+    if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(text)),
       );
     }
   }
 
-  /// Attempts to launch the provided URL (typically an email verification link)
-  /// using the url_launcher package. Prefers opening in an external application (browser/email client).
+  Future<void> debugPrintActiveGames(int userId) async {
+    final db = await DatabaseHelper().database;
+    final rows = await db.query('user_active_games', where: 'user_id = ?', whereArgs: [userId]);
+    print('DEBUG: user_active_games for user $userId:');
+    for (var row in rows) {
+      print(row);
+    }
+  }
+  
+  /// Attempts to launch a verification URL.
   Future<void> _launchVerificationUrl(String url) async {
     final uri = Uri.parse(url);
-    // Check if the URL can be launched.
     if (await canLaunchUrl(uri)) {
-      // Launch the URL, preferring an external application.
       await launchUrl(uri, mode: LaunchMode.externalApplication);
     } else {
-      // Log and show an error if the URL cannot be launched.
       _log.warning('Could not launch verification URL: $url');
       _showSnackBar('Could not open verification link. Please check your email.');
     }
@@ -211,20 +176,17 @@ class CreateAccountScreenState extends State<CreateAccountScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // Build the UI for the Create Account screen.
     return Scaffold(
       appBar: AppBar(
         title: const Text('Create Account'),
       ),
-      // Use a Form widget to enable validation.
       body: Form(
-        key: _formKey, // Associate the GlobalKey with the Form.
-        // Use SingleChildScrollView to prevent overflow on smaller screens.
+        key: _formKey,
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16.0),
           child: Column(
             children: [
-              // Username field with validation.
+              // Username field with validation
               TextFormField(
                 controller: _usernameController,
                 decoration: const InputDecoration(labelText: 'Username'),
@@ -235,104 +197,70 @@ class CreateAccountScreenState extends State<CreateAccountScreen> {
                   if (value.length < 4) {
                     return 'Username must be at least 4 characters';
                   }
-                  return null; // Return null if validation passes.
+                  return null;
                 },
               ),
-              // Email field with validation.
+              // Email field with validation
               TextFormField(
                 controller: _emailController,
                 decoration: const InputDecoration(labelText: 'Email'),
-                keyboardType: TextInputType.emailAddress, // Use email keyboard type.
+                keyboardType: TextInputType.emailAddress,
                 validator: (value) {
                   if (value == null || value.isEmpty) {
                     return 'Please enter an email address';
                   }
-                  // Basic email format validation using RegExp.
-                  final emailRegex = RegExp(r"^[a-zA-Z0-9.a-zA-Z0-9.!#$%&'*+-/=?^_`{|}~]+@[a-zA-Z0-9]+\.[a-zA-Z]+");
+                  final emailRegex = RegExp(
+                      r"^[a-zA-Z0-9.a-zA-Z0-9.!#$%&'*+-/=?^_`{|}~]+@[a-zA-Z0-9]+\.[a-zA-Z]+");
                   if (!emailRegex.hasMatch(value)) {
                     return 'Please enter a valid email address';
                   }
-                  return null; // Return null if validation passes.
-                },
-              ),
-              // First Name field with validation.
-              TextFormField(
-                controller: _firstNameController,
-                decoration: const InputDecoration(labelText: 'First Name'),
-                textCapitalization: TextCapitalization.words, // Capitalize first letter of each word.
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Please enter your first name';
-                  }
                   return null;
                 },
               ),
-              // Last Name field with validation.
-              TextFormField(
-                controller: _lastNameController,
-                decoration: const InputDecoration(labelText: 'Last Name'),
-                textCapitalization: TextCapitalization.words, // Capitalize first letter of each word.
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Please enter your last name';
-                  }
-                  return null;
-                },
-              ),
-              // Password field with validation.
+              // Password field with validation
               TextFormField(
                 controller: _passwordController,
                 decoration: const InputDecoration(labelText: 'Password'),
-                obscureText: true, // Hide password characters.
+                obscureText: true,
                 validator: (value) {
                   if (value == null || value.isEmpty) {
                     return 'Please enter a password';
                   }
-                  if (value.length < 6) { // Example minimum length validation.
+                  if (value.length < 6) {
                     return 'Password must be at least 6 characters';
                   }
-                  return null; // Return null if validation passes.
+                  return null;
                 },
               ),
-              const SizedBox(height: 20), // Spacing.
-
+              const SizedBox(height: 20),
               // --- Game Selection UI ---
-              // Row to display selected game and provide a button to select one.
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  // Display the currently selected game or a prompt to select one.
-                  Expanded( // Allow text to wrap if needed.
+                  Expanded(
                     child: Text(
                       _selectedGameEvent == null
-                          ? 'Select Preferred Game (Required):' // Prompt if no game selected.
-                          : 'Selected Game: $_selectedGameEvent', // Show selected game.
+                          ? 'Select Preferred Game (Required):'
+                          : 'Selected Game: $_selectedGameEvent',
                       style: const TextStyle(fontSize: 16),
                     ),
                   ),
-                  // Button to trigger the game selection process.
                   TextButton(
-                    onPressed: _selectGameEvent, // Call the selection function.
+                    onPressed: _selectGameEvent,
                     child: const Text('Select'),
                   ),
                 ],
               ),
-              // --- End Game Selection UI ---
-
-              const SizedBox(height: 20), // Spacing.
-
-              // Create Account button.
+              const SizedBox(height: 20),
               ElevatedButton(
-                // Disable the button if account creation is in progress.
-                onPressed: _isCreatingAccount ? null : _createAccount,
-                // Conditionally display a loading indicator or the button text.
+                onPressed: (_isCreatingAccount || _selectedGameEvent == null) ? null : _createAccount,
                 child: _isCreatingAccount
-                    ? const SizedBox( // Show a small circular progress indicator.
-                    height: 20,
-                    width: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white)
-                )
-                    : const Text('Create Account'), // Show button text.
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(
+                            strokeWidth: 2, color: Colors.white))
+                    : const Text('Create Account'),
               ),
             ],
           ),
@@ -343,12 +271,9 @@ class CreateAccountScreenState extends State<CreateAccountScreen> {
 
   @override
   void dispose() {
-    // Dispose of the TextEditingControllers to free up resources.
     _usernameController.dispose();
     _passwordController.dispose();
     _emailController.dispose();
-    _firstNameController.dispose();
-    _lastNameController.dispose();
     super.dispose();
   }
 }

--- a/lib/src/golden_ticket/database_helper.dart
+++ b/lib/src/golden_ticket/database_helper.dart
@@ -1,28 +1,52 @@
-// golden_ticket/database_helper.dart
-import 'dart:io'; // Used for File operations (like deleting the database file).
-import 'package:path_provider/path_provider.dart'; // Used to find the correct local path for the database file.
-import 'package:sqflite/sqflite.dart'; // The main SQFlite package for database operations.
-import 'package:sqflite/sqlite_api.dart'; // Import for Batch operations.
-import 'ingot_crucible.dart'; // Data model for the user's selected combinations for a draw.
-import 'dart:convert'; // Used for encoding/decoding JSON data stored in TEXT columns.
-import 'GameResultData.dart'; // Data model for storing cached game results.
+import 'dart:io'; // For file operations (deleting the database file)
+import 'package:path_provider/path_provider.dart'; // To find the local file system path
+import 'package:sqflite/sqflite.dart'; // For SQLite DB operations
+import 'package:sqflite/sqlite_api.dart'; // For batch operations
+import 'ingot_crucible.dart'; // Data model for user's selected combinations
+import 'dart:convert'; // For encoding/decoding JSON
+import 'GameResultData.dart'; // Data model for cached game results
+import 'game_rules.dart'; // Data model for game rules
+import 'package:logging/logging.dart'; // Logging framework
+import 'logging_utils.dart'; // Logger setup utility
 
-import 'game_rules.dart'; // Data model defining the rules for different games.
-import 'package:logging/logging.dart'; // Logging framework.
-import 'logging_utils.dart'; // Utility for logger setup.
+/// Model representing a user's active game selection.
+/// This table records which games a user has currently activated, and when.
+/// Deactivation is soft (row remains, with deactivated_at set).
+class UserActiveGame {
+  final int id; // Primary key
+  final int userId; // Reference to user
+  final String gameName; // Name of the game
+  final DateTime activatedAt; // When the game was activated
+  final DateTime? deactivatedAt; // When the game was deactivated, if any
+
+  UserActiveGame({
+    required this.id,
+    required this.userId,
+    required this.gameName,
+    required this.activatedAt,
+    this.deactivatedAt,
+  });
+
+  /// Construct a UserActiveGame from a database row (map).
+  factory UserActiveGame.fromMap(Map<String, dynamic> map) => UserActiveGame(
+        id: map['id'],
+        userId: map['user_id'],
+        gameName: map['game_name'],
+        activatedAt: DateTime.parse(map['activated_at']),
+        deactivatedAt: map['deactivated_at'] != null ? DateTime.tryParse(map['deactivated_at']) : null,
+      );
+}
 
 // --- GameDrawInfo Class Definition ---
-// Logger specific to the GameDrawInfo class, mainly for parsing warnings.
 final _logGameDrawInfo = Logger('GameDrawInfo');
-/// Represents information about a specific game draw, often fetched from the API.
-/// Includes details like total combinations, user limits, and when the info was last updated.
+/// Contains information about a specific game draw, including combination limits and request counters.
 class GameDrawInfo {
   final String gameName;
   final String drawDate;
   final int? totalCombinations;
   final int? userRequestLimit;
   final int? userCombinationsRequested;
-  final String? archiveChecksum; // New field
+  final String? archiveChecksum;
   final DateTime? lastUpdated;
 
   GameDrawInfo({
@@ -31,10 +55,11 @@ class GameDrawInfo {
     this.totalCombinations,
     this.userRequestLimit,
     this.userCombinationsRequested,
-    this.archiveChecksum, // New field
+    this.archiveChecksum,
     this.lastUpdated,
   });
 
+  /// Convert this object to a map for database storage.
   Map<String, dynamic> toMap() {
     return {
       'game_name': gameName,
@@ -42,11 +67,12 @@ class GameDrawInfo {
       'total_combinations': totalCombinations,
       'user_request_limit': userRequestLimit,
       'user_combinations_requested': userCombinationsRequested,
-      'archive_checksum': archiveChecksum, // New field
+      'archive_checksum': archiveChecksum,
       'last_updated': lastUpdated?.toIso8601String(),
     };
   }
 
+  /// Construct a GameDrawInfo from a database row (map).
   factory GameDrawInfo.fromMap(Map<String, dynamic> map) {
     return GameDrawInfo(
       gameName: map['game_name'] as String,
@@ -54,294 +80,350 @@ class GameDrawInfo {
       totalCombinations: map['total_combinations'] as int?,
       userRequestLimit: map['user_request_limit'] as int?,
       userCombinationsRequested: map['user_combinations_requested'] as int?,
-      archiveChecksum: map['archive_checksum'] as String?, // New field
+      archiveChecksum: map['archive_checksum'] as String?,
       lastUpdated: map['last_updated'] != null ? DateTime.parse(map['last_updated']) : null,
     );
   }
+
   @override
   String toString() {
     return 'GameDrawInfo{gameName: $gameName, drawDate: $drawDate, totalCombinations: $totalCombinations, userRequestLimit: $userRequestLimit, userCombinationsRequested: $userCombinationsRequested, lastUpdated: $lastUpdated}';
   }
 }
-// --- End GameDrawInfo Class Definition ---
 
-
-/// A singleton class providing access to the application's SQLite database.
-/// Handles database initialization, schema creation, migrations, and CRUD operations.
+/// Singleton class for managing the application's SQLite database.
+/// Handles schema creation, migrations, and all CRUD operations.
 class DatabaseHelper {
   // --- Singleton Pattern Implementation ---
-  // Private internal constructor.
   DatabaseHelper._internal() {
-    // Setup logger for the DatabaseHelper instance.
+    // Ensure logger is set up for this instance.
     LoggingUtils.setupLogger(_log);
   }
-  // Static private instance.
   static final DatabaseHelper _instance = DatabaseHelper._internal();
-  // Public factory constructor returns the single instance.
   factory DatabaseHelper() => _instance;
-  // --- End Singleton Pattern ---
-
-  // Logger instance for DatabaseHelper.
   final _log = Logger('DatabaseHelper');
-
-  // Static variable to hold the database instance (lazy initialized).
   static Database? _database;
-  // Database version. Increment this number when the schema changes.
-  static const int _databaseVersion = 2;
-  // Name of the database file.
-  static const String _databaseName = "play_cards.db"; // Kept original name despite table rename.
 
-  /// Getter for the database instance.
-  /// Initializes the database if it hasn't been already.
+  // Database version. Increment when changing schema.
+  static const int _databaseVersion = 3; // Bump version when altering schema.
+  // Filename for the SQLite database.
+  static const String _databaseName = "play_cards.db";
+
+  /// Return the database instance, initializing if needed.
   Future<Database> get database async {
     if (_database != null) return _database!;
-    // If _database is null, initialize it.
     _database = await _initDatabase();
     return _database!;
   }
 
-  /// Initializes the database: finds the path, opens the connection,
-  /// and sets up callbacks for creation and upgrades.
+  /// Initialize the database by opening the file and creating tables if necessary.
   Future<Database> _initDatabase() async {
-    // Get the directory for storing application documents.
     Directory documentsDirectory = await getApplicationDocumentsDirectory();
-    // Construct the full path to the database file.
     String path = "${documentsDirectory.path}/$_databaseName";
     _log.info("Database path: $path (Version: $_databaseVersion)");
-    // Open the database.
     return await openDatabase(
       path,
-      version: _databaseVersion, // Specify the database version.
-      onCreate: _onCreate,       // Callback function if the DB file doesn't exist.
-      onUpgrade: _onUpgrade,     // Callback function if DB version is lower than _databaseVersion.
+      version: _databaseVersion,
+      onCreate: _onCreate,
+      onUpgrade: _onUpgrade,
     );
   }
 
-  /// Called only when the database file is first created on the device.
-  /// Responsible for creating the initial database schema (all tables).
+  /// Called when creating a new database file. Creates all tables and populates defaults.
   Future<void> _onCreate(Database db, int version) async {
     _log.info("Creating database schema (version $version)...");
-    // Use a helper method to create all tables within a single transaction (Batch).
     await _createAllTables(db);
     _log.info("Database tables created.");
-    // Populate the game_rules table with initial data.
     _log.info("Populating game_rules table...");
     await _populateGameRules(db);
     _log.info("game_rules table populated.");
   }
 
-  /// Called when the database version specified during openDatabase is higher
-  /// than the version stored in the existing database file.
-  /// Handles schema migrations between versions.
+  /// Called when upgrading the database version. Applies schema migrations.
   Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
     _log.warning("Upgrading database from version $oldVersion to $newVersion...");
-
-    // --- Migration Logic ---
-    // Apply changes incrementally based on the oldVersion.
-    if (oldVersion < 2) {
-      // Changes introduced in version 2.
-      _log.info("Applying schema changes for version 2...");
-      try {
-        // Rename the 'play_cards' table to 'ingot_crucibles'.
-        await db.execute('ALTER TABLE play_cards RENAME TO ingot_crucibles');
-        _log.info("Renamed table 'play_cards' to 'ingot_crucibles'.");
-        // Add other ALTER TABLE statements or data migration logic for v2 if needed.
-      } catch (e) {
-        _log.severe("Error applying schema changes for version 2: $e");
-        // In a production app, more robust error handling or specific migration
-        // steps would be needed. Recreating tables is a last resort due to data loss.
-        // Example Fallback (DATA LOSS!):
-        // await db.execute('DROP TABLE IF EXISTS play_cards');
-        // await db.execute('DROP TABLE IF EXISTS ingot_crucibles');
-        // await _createIngotCruciblesTable(db); // Assuming helper takes Database
-        // _log.warning("Fallback: Dropped and recreated ingot_crucibles table due to migration error.");
-      }
+    // Migration for user_active_games table (version 3)
+    if (oldVersion < 3) {
+      _log.info("Adding user_active_games table for v3...");
+      await db.execute('''
+        CREATE TABLE IF NOT EXISTS user_active_games(
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          user_id INTEGER NOT NULL,
+          game_name TEXT NOT NULL,
+          activated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          deactivated_at DATETIME
+        )
+      ''');
+      _log.info("user_active_games table created (upgrade).");
     }
-    // Example for future version:
-    // if (oldVersion < 3) {
-    //   // Apply changes for version 3
-    //   await db.execute('ALTER TABLE ...');
-    // }
-    // --- End Migration Logic ---
-
     _log.info("Database upgrade complete.");
   }
 
-  /// Helper method to create all database tables using a Batch operation
-  /// for better performance during initial creation.
+  /// Create all database tables using a batch operation.
   Future<void> _createAllTables(Database db) async {
-    // Create a batch object.
     Batch batch = db.batch();
-    // Add CREATE TABLE statements to the batch.
-    _createIngotCruciblesTable(batch); // Renamed table.
+    _createIngotCruciblesTable(batch);
     _createGameResultsCacheTable(batch);
     _createUserProfilesTable(batch);
     _createUserGameProgressTable(batch);
     _createGameRulesTable(batch);
     _createGameDrawInfoTable(batch);
     _createIngotCollectionTable(batch);
-    // Commit the batch - executes all statements in a single transaction.
+    _createUserActiveGamesTable(batch); // Add user_active_games table
     await batch.commit(noResult: true);
   }
 
-
-  // --- Table Creation Methods ---
+  /// Defines and creates the user_active_games table, which tracks games a user has activated.
+  /// Each row indicates a game the user is currently playing (deactivated_at IS NULL) or has played in the past.
+  void _createUserActiveGamesTable(Batch batch) {
+    batch.execute('''
+      CREATE TABLE IF NOT EXISTS user_active_games(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        game_name TEXT NOT NULL,
+        activated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        deactivated_at DATETIME
+      )
+    ''');
+    _log.fine("Schema: user_active_games defined.");
+    // Create index for fast lookups by user_id.
+    batch.execute('CREATE INDEX IF NOT EXISTS idx_user_active_games_user ON user_active_games (user_id)');
+  }
 
   /// Defines and creates the 'ingot_crucibles' table schema (formerly 'play_cards').
-  /// Stores the user's selected combinations (ingots) for a specific draw.
   void _createIngotCruciblesTable(Batch batch) {
     batch.execute('''
       CREATE TABLE ingot_crucibles(
-        id INTEGER PRIMARY KEY AUTOINCREMENT, -- Auto-incrementing primary key.
-        name TEXT,                             -- Optional name for the crucible.
-        user_id INTEGER,                       -- Foreign key linking to the user.
-        submitted_date TEXT NOT NULL,          -- Timestamp of last save/submission (ISO 8601 string).
-        status TEXT NOT NULL,                  -- Status ('draft', 'submitted', 'locked').
-        combinations TEXT NOT NULL,            -- JSON string representing List<CombinationWithId>.
-        draw_date TEXT NOT NULL                -- Target draw date ('yyyy-MM-dd').
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT,
+        user_id INTEGER,
+        submitted_date TEXT NOT NULL,
+        status TEXT NOT NULL,
+        combinations TEXT NOT NULL,
+        draw_date TEXT NOT NULL
       )
     ''');
     _log.fine("Schema: ingot_crucibles defined.");
-    // Add an index for faster lookups based on user and draw date.
     batch.execute('CREATE INDEX IF NOT EXISTS idx_crucible_user_draw ON ingot_crucibles (user_id, draw_date)');
     _log.fine("Index: idx_crucible_user_draw defined.");
   }
 
   /// Defines and creates the 'game_results_cache' table schema.
-  /// Stores fetched game results locally to reduce API calls.
   void _createGameResultsCacheTable(Batch batch) {
     batch.execute('''
       CREATE TABLE game_results_cache(
-        game_name TEXT NOT NULL,            -- Name of the game.
-        draw_date TEXT NOT NULL,            -- Date of the draw ('yyyy-MM-dd').
-        last_draw_numbers TEXT,             -- JSON string of winning numbers (List<int>).
-        bonus_number INTEGER,               -- Bonus number, if applicable.
-        total_combinations INTEGER,         -- Total combinations for the game (informational).
-        odds_6_6 REAL,                      -- Odds for matching 6/6 (example).
-        odds_5_6_plus REAL,                 -- Odds for matching 5/6 + bonus (example).
-        odds_5_6 REAL,                      -- Odds for matching 5/6 (example).
-        odds_4_6 REAL,                      -- Odds for matching 4/6 (example).
-        odds_3_6 REAL,                      -- Odds for matching 3/6 (example).
-        odds_2_6_plus REAL,                 -- Odds for matching 2/6 + bonus (example).
-        odds_2_6 REAL,                      -- Odds for matching 2/6 (example).
-        odds_any_prize REAL,                -- Overall odds of winning any prize.
-        user_score INTEGER,                 -- User's score for this specific draw.
-        fetched_at TEXT NOT NULL,           -- Timestamp when this result was fetched (ISO 8601 string).
-        new_draw_flag INTEGER DEFAULT 0 NOT NULL, -- Flag (1=new, 0=seen) to indicate unread results.
-        win_id TEXT,                        -- Unique identifier for the winning result set (if provided by API).
-        archive_password TEXT,              -- Password for result archive (if provided).
-        archive_checksum TEXT,              -- Checksum for result archive verification (if provided).
-        PRIMARY KEY (game_name, draw_date)  -- Composite primary key.
+        game_name TEXT NOT NULL,
+        draw_date TEXT NOT NULL,
+        last_draw_numbers TEXT,
+        bonus_number INTEGER,
+        total_combinations INTEGER,
+        odds_6_6 REAL,
+        odds_5_6_plus REAL,
+        odds_5_6 REAL,
+        odds_4_6 REAL,
+        odds_3_6 REAL,
+        odds_2_6_plus REAL,
+        odds_2_6 REAL,
+        odds_any_prize REAL,
+        user_score INTEGER,
+        fetched_at TEXT NOT NULL,
+        new_draw_flag INTEGER DEFAULT 0 NOT NULL,
+        win_id TEXT,
+        archive_password TEXT,
+        archive_checksum TEXT,
+        PRIMARY KEY (game_name, draw_date)
       )
     ''');
     _log.fine("Schema: game_results_cache defined.");
   }
 
   /// Defines and creates the 'user_profiles' table schema.
-  /// Stores basic user profile information.
   void _createUserProfilesTable(Batch batch) {
     batch.execute('''
       CREATE TABLE user_profiles(
-        user_id INTEGER PRIMARY KEY,        -- User ID from the backend, primary key.
-        membership_level TEXT,              -- User's membership level (e.g., 'Family').
-        global_awards TEXT,                 -- JSON string representing List<String> of global awards.
-        global_statistics TEXT,             -- JSON string representing Map<String, dynamic> of global stats.
-        last_updated TEXT NOT NULL          -- Timestamp of last update (ISO 8601 string).
+        user_id INTEGER PRIMARY KEY,
+        membership_level TEXT,
+        global_awards TEXT,
+        global_statistics TEXT,
+        last_updated TEXT NOT NULL
       )
     ''');
     _log.fine("Schema: user_profiles defined.");
   }
 
   /// Defines and creates the 'user_game_progress' table schema.
-  /// Stores user-specific progress and stats for each game they participate in.
   void _createUserGameProgressTable(Batch batch) {
     batch.execute('''
       CREATE TABLE user_game_progress(
-        user_id INTEGER NOT NULL,           -- Foreign key linking to user_profiles.
-        game_name TEXT NOT NULL,            -- Name of the game.
-        game_score INTEGER NOT NULL DEFAULT 0, -- User's score for this game.
-        game_awards TEXT,                   -- JSON string representing List<String> of game-specific awards.
-        game_statistics TEXT,               -- JSON string representing Map<String, dynamic> of game stats.
-        membership_level TEXT,              -- User's level at the time of last play (denormalized, optional).
-        last_played TEXT,                   -- Timestamp of last interaction with this game (ISO 8601 string).
-        PRIMARY KEY (user_id, game_name),   -- Composite primary key.
-        FOREIGN KEY (user_id) REFERENCES user_profiles(user_id) ON DELETE CASCADE -- Delete progress if user profile is deleted.
+        user_id INTEGER NOT NULL,
+        game_name TEXT NOT NULL,
+        game_score INTEGER NOT NULL DEFAULT 0,
+        game_awards TEXT,
+        game_statistics TEXT,
+        membership_level TEXT,
+        last_played TEXT,
+        PRIMARY KEY (user_id, game_name),
+        FOREIGN KEY (user_id) REFERENCES user_profiles(user_id) ON DELETE CASCADE
       )
     ''');
     _log.fine("Schema: user_game_progress defined.");
-    // Add index for faster lookups by user_id.
     batch.execute('CREATE INDEX IF NOT EXISTS idx_user_game_progress_user ON user_game_progress (user_id)');
     _log.fine("Index: idx_user_game_progress_user defined.");
   }
 
   /// Defines and creates the 'game_rules' table schema.
-  /// Stores the rules and parameters for each supported game.
   void _createGameRulesTable(Batch batch) {
     batch.execute('''
       CREATE TABLE game_rules(
-        game_name TEXT PRIMARY KEY NOT NULL, -- Name of the game, primary key.
-        total_numbers INTEGER NOT NULL,      -- Total numbers in the pool (e.g., 49).
-        regular_balls_drawn INTEGER NOT NULL,-- Number of regular balls drawn (e.g., 6).
-        bonus_ball_pool INTEGER NOT NULL,    -- Size of the bonus ball pool (can be same as total_numbers).
-        bonus_balls_drawn INTEGER NOT NULL,  -- Number of bonus balls drawn (e.g., 1).
-        draw_schedule TEXT,                  -- String describing draw days/times/timezones.
-        prize_tier_format TEXT,              -- String describing prize tiers (e.g., 'matches/6+').
-        official_odds_json TEXT              -- JSON string storing official odds display strings (Map<String, String>).
+        game_name TEXT PRIMARY KEY NOT NULL,
+        total_numbers INTEGER NOT NULL,
+        regular_balls_drawn INTEGER NOT NULL,
+        bonus_ball_pool INTEGER NOT NULL,
+        bonus_balls_drawn INTEGER NOT NULL,
+        draw_schedule TEXT,
+        prize_tier_format TEXT,
+        official_odds_json TEXT
       )
     ''');
     _log.fine("Schema: game_rules defined.");
   }
+  
+  /// Fetches all game rules from the game_rules table.
+  Future<List<GameRule>> fetchAllGameRules() async {
+    final db = await database;
+    final List<Map<String, dynamic>> maps = await db.query('game_rules');
+    // Use GameRule.fromMap for each row
+    return List.generate(maps.length, (i) => GameRule.fromMap(maps[i]));
+  }
 
   /// Defines and creates the 'game_draw_info' table schema.
-  /// Stores information about specific draws, like limits and dates.
   void _createGameDrawInfoTable(Batch batch) {
     batch.execute('''
       CREATE TABLE game_draw_info(
-        game_name TEXT NOT NULL,            -- Name of the game.
-        draw_date TEXT NOT NULL,            -- Date of the draw ('yyyy-MM-dd').
-        total_combinations INTEGER,         -- Total combinations for the game.
-        user_request_limit INTEGER,         -- Max ingots user can request for this draw.
-        user_combinations_requested INTEGER,-- Ingots user has requested so far.
-        last_updated TEXT,                  -- Timestamp when this info was last updated (ISO 8601 string).
+        game_name TEXT NOT NULL,
+        draw_date TEXT NOT NULL,
+        total_combinations INTEGER,
+        user_request_limit INTEGER,
+        user_combinations_requested INTEGER,
+        last_updated TEXT,
         archive_checksum TEXT,
-        PRIMARY KEY (game_name, draw_date)  -- Composite primary key.
+        PRIMARY KEY (game_name, draw_date)
       )
     ''');
     _log.fine("Schema: game_draw_info defined.");
   }
 
   /// Defines and creates the 'ingot_collection' table schema.
-  /// Stores the individual combinations (ingots) a user has "smelted" but not yet placed in a crucible.
   void _createIngotCollectionTable(Batch batch) {
     batch.execute('''
       CREATE TABLE ingot_collection(
-        ingot_id INTEGER PRIMARY KEY,       -- Unique ID for the ingot (likely from API), primary key.
-        user_id INTEGER NOT NULL,           -- User who owns the ingot.
-        game_name TEXT NOT NULL,            -- Game the ingot belongs to.
-        draw_date TEXT NOT NULL,            -- Draw date the ingot is associated with ('yyyy-MM-dd').
-        numbers TEXT NOT NULL,              -- JSON string representing the combination numbers (List<int>).
-        added_timestamp TEXT NOT NULL       -- Timestamp when the ingot was added (ISO 8601 string).
+        ingot_id INTEGER PRIMARY KEY,
+        user_id INTEGER NOT NULL,
+        game_name TEXT NOT NULL,
+        draw_date TEXT NOT NULL,
+        numbers TEXT NOT NULL,
+        added_timestamp TEXT NOT NULL
       )
     ''');
-    // Add index for faster lookups of a user's collection for a specific game/draw.
     batch.execute('CREATE INDEX IF NOT EXISTS idx_ingot_collection_user_game_draw ON ingot_collection (user_id, game_name, draw_date)');
     _log.fine("Schema: ingot_collection defined with index.");
   }
-  // --- End Table Creation Methods ---
 
   /// Populates the 'game_rules' table with initial data defined in GameRules.gameRulesData.
-  /// Uses a Batch for efficiency.
   Future<void> _populateGameRules(Database db) async {
     Batch populateBatch = db.batch();
-    // Iterate through the predefined game rules.
     for (final rule in GameRules.gameRulesData) {
       _log.fine("Inserting game rule: ${rule.toString()}");
-      // Insert each rule into the table. Use 'replace' to handle potential re-runs.
       populateBatch.insert('game_rules', rule.toMap(), conflictAlgorithm: ConflictAlgorithm.replace);
     }
-    // Execute the batch insertion.
     await populateBatch.commit(noResult: true);
     _log.info("game_rules table populated successfully.");
+  }
+
+  // --- User Active Games Methods ---
+
+  /// Returns a list of game names for the games the user has activated (still active).
+  /// Only rows where deactivated_at IS NULL are considered active.
+  Future<List<String>> getActiveGamesForUser(int userId) async {
+    final db = await database;
+    final res = await db.query(
+      'user_active_games',
+      columns: ['game_name'],
+      where: 'user_id = ? AND deactivated_at IS NULL',
+      whereArgs: [userId],
+    );
+    // Only return the game_name values as a list of strings.
+    return res.map((row) => row['game_name'] as String).toList();
+  }
+
+  /// Activates a game for the user.
+  /// If the row exists and is deactivated, reactivates it. If it does not exist, inserts a new row.
+  /// Now includes error handling and logging.
+  Future<void> activateGameForUser(int userId, String gameName) async {
+    try {
+      final db = await database;
+      // Query for an existing row for this user/game.
+      final res = await db.query(
+        'user_active_games',
+        where: 'user_id = ? AND game_name = ?',
+        whereArgs: [userId, gameName],
+      );
+
+      if (res.isNotEmpty && res.first['deactivated_at'] != null) {
+        // Row exists but is currently deactivated: reactivate it.
+        await db.update(
+          'user_active_games',
+          {
+            'deactivated_at': null,
+            'activated_at': DateTime.now().toIso8601String(),
+          },
+          where: 'id = ?',
+          whereArgs: [res.first['id']],
+        );
+        print('INFO: Reactivated game "$gameName" for user $userId.');
+      } else if (res.isEmpty) {
+        // No row exists: insert new active row.
+        await db.insert('user_active_games', {
+          'user_id': userId,
+          'game_name': gameName,
+          'activated_at': DateTime.now().toIso8601String(),
+        });
+        print('INFO: Activated new game "$gameName" for user $userId.');
+      } else {
+        // Already active, do nothing.
+        print('INFO: Game "$gameName" already active for user $userId.');
+      }
+    } catch (e, stack) {
+      // Log the error and optionally rethrow or handle as needed
+      print('ERROR: Failed to activate game "$gameName" for user $userId: $e');
+      print(stack);
+      // Optionally: rethrow or handle error as appropriate for your app
+      // throw e;
+    }
+  }
+
+  /// Deactivates a game for the user (soft delete).
+  /// Sets deactivated_at to current time, leaving the row for history.
+  Future<void> deactivateGameForUser(int userId, String gameName) async {
+    final db = await database;
+    await db.update(
+      'user_active_games',
+      {'deactivated_at': DateTime.now().toIso8601String()},
+      where: 'user_id = ? AND game_name = ? AND deactivated_at IS NULL',
+      whereArgs: [userId, gameName],
+    );
+  }
+
+  /// Returns a list of GameRule objects for all games the user currently has activated.
+  /// This performs a join with the game_rules table to provide the full rules for each active game.
+  Future<List<GameRule>> getActiveGameRulesForUser(int userId) async {
+    final db = await database;
+    final res = await db.rawQuery('''
+      SELECT gr.* FROM game_rules gr
+      JOIN user_active_games uag ON gr.game_name = uag.game_name
+      WHERE uag.user_id = ? AND uag.deactivated_at IS NULL
+    ''', [userId]);
+    return res.map((row) => GameRule.fromMap(row)).toList();
   }
 
   // --- CRUD Methods for IngotCrucible ---
@@ -351,10 +433,9 @@ class DatabaseHelper {
   Future<int> insertIngotCrucible(IngotCrucible crucible) async {
     final db = await database;
     _log.fine("Inserting/Replacing IngotCrucible: ${crucible.toMap()}");
-    // Use insert with conflictAlgorithm.replace for upsert behavior based on primary key (id).
     int id = await db.insert(
-      'ingot_crucibles', // Use the correct table name.
-      crucible.toMap(), // Convert object to map for insertion.
+      'ingot_crucibles',
+      crucible.toMap(),
       conflictAlgorithm: ConflictAlgorithm.replace,
     );
     _log.info("IngotCrucible inserted/replaced with ID: $id");
@@ -365,21 +446,18 @@ class DatabaseHelper {
   /// Returns the IngotCrucible object or null if not found.
   Future<IngotCrucible?> getUserCrucibleForDraw(int userId, String drawDate) async {
     final db = await database;
-    // Query the table for matching user_id and draw_date.
     final List<Map<String, dynamic>> maps = await db.query(
-      'ingot_crucibles', // Use the correct table name.
-      where: 'user_id = ? AND draw_date = ?', // SQL WHERE clause.
-      whereArgs: [userId, drawDate], // Arguments for the WHERE clause.
-      limit: 1, // Expect only one record per user/draw.
+      'ingot_crucibles',
+      where: 'user_id = ? AND draw_date = ?',
+      whereArgs: [userId, drawDate],
+      limit: 1,
     );
-
-    // If a record is found, convert it from a map to an IngotCrucible object.
     if (maps.isNotEmpty) {
       _log.fine("Found IngotCrucible for user $userId, draw $drawDate: ${maps.first}");
       return IngotCrucible.fromMap(maps.first);
     } else {
       _log.fine("No IngotCrucible found for user $userId, draw $drawDate.");
-      return null; // Return null if no record found.
+      return null;
     }
   }
 
@@ -387,20 +465,17 @@ class DatabaseHelper {
   /// Returns true if a record exists, false otherwise.
   Future<bool> hasCrucibleForDrawDate(int userId, String drawDate) async {
     final db = await database;
-    // Query only for the 'id' column to check existence efficiently.
     final List<Map<String, dynamic>> maps = await db.query(
-      'ingot_crucibles', // Use the correct table name.
-      columns: ['id'], // Only need one column to check existence.
+      'ingot_crucibles',
+      columns: ['id'],
       where: 'user_id = ? AND draw_date = ?',
       whereArgs: [userId, drawDate],
       limit: 1,
     );
-    bool exists = maps.isNotEmpty; // True if the query returned any rows.
+    bool exists = maps.isNotEmpty;
     _log.fine("Checked for IngotCrucible existence for user $userId, draw $drawDate: $exists");
     return exists;
   }
-  // --- End Ingot Crucible Methods ---
-
 
   // --- CRUD Methods for Ingot Collection ---
 
@@ -410,28 +485,26 @@ class DatabaseHelper {
     required int userId,
     required String gameName,
     required String drawDate,
-    required int ingotId, // The unique ID of the ingot from the API.
-    required List<int> numbers, // The combination numbers.
+    required int ingotId,
+    required List<int> numbers,
   }) async {
     final db = await database;
-    // Prepare data map for insertion.
     final data = {
       'ingot_id': ingotId,
       'user_id': userId,
       'game_name': gameName,
       'draw_date': drawDate,
-      'numbers': jsonEncode(numbers), // Store numbers list as JSON string.
-      'added_timestamp': DateTime.now().toIso8601String(), // Record when added.
+      'numbers': jsonEncode(numbers),
+      'added_timestamp': DateTime.now().toIso8601String(),
     };
     _log.fine("Adding Ingot to Collection: $data");
     try {
-      // Insert data, replacing any existing entry with the same ingot_id.
       int id = await db.insert('ingot_collection', data, conflictAlgorithm: ConflictAlgorithm.replace);
       _log.info("Ingot ID $ingotId added/replaced in collection for $userId/$gameName/$drawDate. Result: $id");
-      return id; // Returns the row ID (or ingot_id if it's the primary key).
+      return id;
     } catch (e) {
       _log.severe("Error adding ingot $ingotId to collection: $e");
-      rethrow; // Rethrow the exception to be handled by the caller.
+      rethrow;
     }
   }
 
@@ -442,20 +515,16 @@ class DatabaseHelper {
     List<CombinationWithId> collection = [];
     _log.fine("Getting Ingot Collection for $userId/$gameName/$drawDate");
     try {
-      // Query the collection table.
       final List<Map<String, dynamic>> maps = await db.query(
         'ingot_collection',
         where: 'user_id = ? AND game_name = ? AND draw_date = ?',
         whereArgs: [userId, gameName, drawDate],
-        orderBy: 'added_timestamp DESC', // Order by most recently added.
+        orderBy: 'added_timestamp DESC',
       );
-      // Convert each map result into a CombinationWithId object.
       for (var map in maps) {
         try {
-          // Decode the numbers JSON string.
           final numbersList = jsonDecode(map['numbers'] as String);
           if (numbersList is List) {
-            // Create the object and add to the list.
             collection.add(CombinationWithId(
               ingotId: map['ingot_id'] as int,
               numbers: numbersList.map((e) => int.parse(e.toString())).toList(),
@@ -480,7 +549,6 @@ class DatabaseHelper {
     final db = await database;
     _log.fine("Removing Ingot ID $ingotId from Collection.");
     try {
-      // Delete the row matching the ingotId.
       int count = await db.delete('ingot_collection', where: 'ingot_id = ?', whereArgs: [ingotId]);
       if (count > 0) {
         _log.info("Removed Ingot ID $ingotId from collection.");
@@ -501,7 +569,6 @@ class DatabaseHelper {
     final db = await database;
     _log.fine("Clearing Ingot Collection for $userId/$gameName/$drawDate.");
     try {
-      // Delete rows matching the user, game, and draw date.
       int count = await db.delete(
         'ingot_collection',
         where: 'user_id = ? AND game_name = ? AND draw_date = ?',
@@ -514,8 +581,6 @@ class DatabaseHelper {
       rethrow;
     }
   }
-  // --- End Ingot Collection Methods ---
-
 
   // --- CRUD Methods for Game Results Cache ---
 
@@ -523,9 +588,7 @@ class DatabaseHelper {
   /// Sets the 'new_draw_flag' based on whether actual draw numbers are present.
   Future<int> insertOrUpdateGameResultCache(GameResultData result) async {
     final db = await database;
-    // Convert the GameResultData object to a map.
     Map<String, dynamic> dataMap = result.toMap();
-    // Set the new_draw_flag: 1 if actual numbers exist, 0 for placeholders.
     if (result.drawNumbers != null && result.drawNumbers!.isNotEmpty) {
       dataMap['new_draw_flag'] = 1;
       _log.fine("Setting new_draw_flag to 1 for actual results: ${result.gameName}/${result.drawDate}");
@@ -533,11 +596,9 @@ class DatabaseHelper {
       dataMap['new_draw_flag'] = 0;
       _log.fine("Setting new_draw_flag to 0 for placeholder: ${result.gameName}/${result.drawDate}");
     }
-    // Record the time the data was fetched/cached.
     dataMap['fetched_at'] = DateTime.now().toIso8601String();
 
     _log.fine("Inserting/Replacing GameResultCache: ${dataMap.keys.map((k) => '$k: ${dataMap[k]}').join(', ')}");
-    // Use insert with replace conflict algorithm for upsert behavior based on primary key (game_name, draw_date).
     int resultId = await db.insert(
       'game_results_cache',
       dataMap,
@@ -551,15 +612,13 @@ class DatabaseHelper {
   /// Returns the GameResultData object or null if not found in cache.
   Future<GameResultData?> getGameResultFromCache(String gameName, String drawDate) async {
     final db = await database;
-    // Query the cache table.
     final List<Map<String, dynamic>> maps = await db.query(
       'game_results_cache',
       where: 'game_name = ? AND draw_date = ?',
       whereArgs: [gameName, drawDate],
-      limit: 1, // Expect only one result per game/draw.
+      limit: 1,
     );
 
-    // If found, convert the map to a GameResultData object.
     if (maps.isNotEmpty) {
       _log.fine("Found GameResultCache for $gameName/$drawDate: ${maps.first}");
       return GameResultData.fromMap(maps.first);
@@ -575,18 +634,15 @@ class DatabaseHelper {
   Future<int> clearNewDrawFlag(String gameName, String drawDate) async {
     final db = await database;
     _log.fine("Clearing new_draw_flag for $gameName / $drawDate.");
-    // Update the flag to 0 only if it's currently 1.
     int count = await db.update(
       'game_results_cache',
-      {'new_draw_flag': 0}, // Values to update.
-      where: 'game_name = ? AND draw_date = ? AND new_draw_flag = ?', // Condition.
-      whereArgs: [gameName, drawDate, 1], // Arguments for the condition.
+      {'new_draw_flag': 0},
+      where: 'game_name = ? AND draw_date = ? AND new_draw_flag = ?',
+      whereArgs: [gameName, drawDate, 1],
     );
     _log.info("Cleared new_draw_flag for $gameName / $drawDate. Rows affected: $count");
     return count;
   }
-  // --- End Game Results Cache Methods ---
-
 
   // --- CRUD Methods for User Profiles ---
 
@@ -594,22 +650,19 @@ class DatabaseHelper {
   Future<int> insertOrUpdateUserProfile({
     required int userId,
     String? membershipLevel,
-    List<String>? globalAwards, // Stored as JSON string.
-    String? globalStatistics, // Stored as JSON string.
+    List<String>? globalAwards,
+    String? globalStatistics,
   }) async {
     final db = await database;
-    // Prepare data map, encoding lists/maps as JSON.
     final data = {
       'user_id': userId,
       'membership_level': membershipLevel,
       'global_awards': globalAwards != null ? jsonEncode(globalAwards) : null,
-      'global_statistics': globalStatistics, // Assuming already a JSON string or compatible.
+      'global_statistics': globalStatistics,
       'last_updated': DateTime.now().toIso8601String(),
     };
-    // Remove null values to avoid inserting NULLs unless intended.
     data.removeWhere((key, value) => value == null);
     _log.fine("Inserting/Replacing UserProfile: $data");
-    // Use insert with replace for upsert based on primary key (user_id).
     int id = await db.insert(
       'user_profiles',
       data,
@@ -623,14 +676,12 @@ class DatabaseHelper {
   /// Returns a map representing the profile or null if not found.
   Future<Map<String, dynamic>?> getUserProfile(int userId) async {
     final db = await database;
-    // Query by user_id.
     final List<Map<String, dynamic>> maps = await db.query(
       'user_profiles',
       where: 'user_id = ?',
       whereArgs: [userId],
       limit: 1,
     );
-    // Return the map if found.
     if (maps.isNotEmpty) {
       _log.fine("Found UserProfile for user $userId: ${maps.first}");
       return maps.first;
@@ -639,8 +690,6 @@ class DatabaseHelper {
       return null;
     }
   }
-  // --- End User Profiles Methods ---
-
 
   // --- CRUD Methods for User Game Progress ---
 
@@ -650,21 +699,18 @@ class DatabaseHelper {
     required int userId,
     required String gameName,
     int scoreToAdd = 0,
-    List<String>? gameAwardsToAdd, // Stored as JSON list.
-    String? gameStatistics, // Stored as JSON map string.
+    List<String>? gameAwardsToAdd,
+    String? gameStatistics,
     String? membershipLevel,
   }) async {
     final db = await database;
-    // Get existing progress to merge data.
     final existing = await getUserGameProgress(userId, gameName);
     int currentScore = 0;
     List<String> currentAwards = [];
     Map<String, dynamic> currentStats = {};
-    // If existing progress found, parse its data.
     if (existing != null) {
       currentScore = existing['game_score'] ?? 0;
       try {
-        // Safely decode JSON strings for awards and stats.
         if (existing['game_awards'] != null) {
           currentAwards = List<String>.from(jsonDecode(existing['game_awards']));
         }
@@ -675,14 +721,11 @@ class DatabaseHelper {
         _log.warning("Error decoding existing progress JSON for $userId/$gameName: $e");
       }
     }
-    // Calculate new score.
     int newScore = currentScore + scoreToAdd;
-    // Merge awards (using a Set to ensure uniqueness).
     if (gameAwardsToAdd != null) {
       currentAwards.addAll(gameAwardsToAdd);
       currentAwards = currentAwards.toSet().toList();
     }
-    // Merge statistics (assuming new statistics override old ones with the same key).
     if (gameStatistics != null) {
       try {
         currentStats.addAll(jsonDecode(gameStatistics));
@@ -690,20 +733,17 @@ class DatabaseHelper {
         _log.warning("Error decoding new gameStatistics JSON for $userId/$gameName: $e");
       }
     }
-    // Prepare data map for upsert.
     final data = {
       'user_id': userId,
       'game_name': gameName,
       'game_score': newScore,
-      'game_awards': jsonEncode(currentAwards), // Encode merged awards.
-      'game_statistics': jsonEncode(currentStats), // Encode merged stats.
+      'game_awards': jsonEncode(currentAwards),
+      'game_statistics': jsonEncode(currentStats),
       'membership_level': membershipLevel,
-      'last_played': DateTime.now().toIso8601String(), // Update last played timestamp.
+      'last_played': DateTime.now().toIso8601String(),
     };
-    // Remove null values except for score/awards/stats which might be intentionally empty/zero.
     data.removeWhere((key, value) => key != 'game_score' && key != 'game_awards' && key != 'game_statistics' && value == null);
     _log.fine("Upserting UserGameProgress: $data");
-    // Use insert with replace for upsert based on primary key (user_id, game_name).
     int id = await db.insert(
       'user_game_progress',
       data,
@@ -717,14 +757,12 @@ class DatabaseHelper {
   /// Returns a map representing the progress or null if not found.
   Future<Map<String, dynamic>?> getUserGameProgress(int userId, String gameName) async {
     final db = await database;
-    // Query by user_id and game_name.
     final List<Map<String, dynamic>> maps = await db.query(
       'user_game_progress',
       where: 'user_id = ? AND game_name = ?',
       whereArgs: [userId, gameName],
       limit: 1,
     );
-    // Return the map if found.
     if (maps.isNotEmpty) {
       _log.fine("Found UserGameProgress for $userId/$gameName: ${maps.first}");
       return maps.first;
@@ -738,7 +776,6 @@ class DatabaseHelper {
   /// Returns a list of maps.
   Future<List<Map<String, dynamic>>> getAllUserGameProgress(int userId) async {
     final db = await database;
-    // Query by user_id, order by game name.
     final List<Map<String, dynamic>> maps = await db.query(
       'user_game_progress',
       where: 'user_id = ?',
@@ -752,18 +789,14 @@ class DatabaseHelper {
   /// Calculates the total score for a user across all games.
   Future<int> getTotalUserScore(int userId) async {
     final db = await database;
-    // Use a raw SQL query with SUM aggregation.
     final List<Map<String, dynamic>> result = await db.rawQuery(
       'SELECT SUM(game_score) as total_score FROM user_game_progress WHERE user_id = ?',
       [userId],
     );
-    // Extract the sum value, defaulting to 0 if null.
     int totalScore = Sqflite.firstIntValue(result) ?? 0;
     _log.fine("Calculated total score for user $userId: $totalScore");
     return totalScore;
   }
-  // --- End User Game Progress Methods ---
-
 
   // --- Methods for Game Rules ---
 
@@ -771,36 +804,29 @@ class DatabaseHelper {
   /// Returns a GameRule object or null if not found.
   Future<GameRule?> getGameRule(String gameName) async {
     final db = await database;
-    // Query the game_rules table by game_name.
     final List<Map<String, dynamic>> maps = await db.query(
       'game_rules',
-      columns: GameRule.columns, // Specify columns defined in the GameRule model.
+      columns: GameRule.columns,
       where: 'game_name = ?',
       whereArgs: [gameName],
       limit: 1,
     );
-    // If found, convert the map to a GameRule object.
     if (maps.isNotEmpty) {
       return GameRule.fromMap(maps.first);
     }
     _log.warning("Game rule not found in DB for: $gameName");
     return null;
   }
-  // --- End Game Rules Methods ---
-
 
   // --- Methods for Game Draw Info ---
 
   /// Inserts or updates information about a specific game draw.
   Future<int> upsertGameDrawInfo(GameDrawInfo drawInfo) async {
     final db = await database;
-    // Convert object to map.
     Map<String, dynamic> dataMap = drawInfo.toMap();
-    // Set the last_updated timestamp.
     dataMap['last_updated'] = DateTime.now().toIso8601String();
 
     _log.fine("Upserting GameDrawInfo: ${dataMap.keys.map((k) => '$k: ${dataMap[k]}').join(', ')}");
-    // Use insert with replace for upsert based on primary key (game_name, draw_date).
     int resultId = await db.insert(
       'game_draw_info',
       dataMap,
@@ -818,7 +844,6 @@ class DatabaseHelper {
     List<Map<String, dynamic>> maps;
 
     if (drawDate != null) {
-      // Fetch info for a specific date.
       _log.fine("Querying GameDrawInfo for specific date: $gameName / $drawDate");
       maps = await db.query(
         'game_draw_info',
@@ -827,24 +852,22 @@ class DatabaseHelper {
         limit: 1,
       );
     } else {
-      // Fetch the latest info for the game by ordering by date descending.
       _log.fine("Querying latest GameDrawInfo for game: $gameName");
       try {
         maps = await db.query(
           'game_draw_info',
           where: 'game_name = ?',
           whereArgs: [gameName],
-          orderBy: 'draw_date DESC', // Get the most recent date first.
+          orderBy: 'draw_date DESC',
           limit: 1,
         );
         _log.fine("Raw query result for latest GameDrawInfo ($gameName): $maps");
       } catch (e, stacktrace) {
         _log.severe("Error querying latest GameDrawInfo for $gameName: $e\nStack: $stacktrace");
-        maps = []; // Return empty list on error.
+        maps = [];
       }
     }
 
-    // If found, convert map to GameDrawInfo object.
     if (maps.isNotEmpty) {
       _log.fine("Found GameDrawInfo for $gameName (Date: ${drawDate ?? 'Latest'}): ${maps.first}");
       return GameDrawInfo.fromMap(maps.first);
@@ -853,8 +876,6 @@ class DatabaseHelper {
       return null;
     }
   }
-  // --- End Game Draw Info Methods ---
-
 
   // --- Utility Methods ---
 
@@ -862,13 +883,11 @@ class DatabaseHelper {
   /// WARNING: This causes complete data loss. Use with extreme caution, typically only during development.
   Future<void> resetDatabase() async {
     try {
-      // Close the database if it's open.
       if (_database != null && _database!.isOpen) {
         await _database!.close();
         _log.info("Database closed.");
       }
-      _database = null; // Clear the static instance.
-      // Get the path and delete the file.
+      _database = null;
       Directory documentsDirectory = await getApplicationDocumentsDirectory();
       String path = "${documentsDirectory.path}/$_databaseName";
       File dbFile = File(path);
@@ -878,13 +897,12 @@ class DatabaseHelper {
       } else {
         _log.info("Database file not found at path: $path (already deleted or never created).");
       }
-      // Re-initialize the database, triggering onCreate.
       _log.info("Re-initializing database...");
       _database = await _initDatabase();
       _log.info("Database reset and re-initialized successfully.");
     } catch (e) {
       _log.severe("Error resetting database: $e");
-      rethrow; // Rethrow exception after logging.
+      rethrow;
     }
   }
 
@@ -893,21 +911,18 @@ class DatabaseHelper {
   Future<bool> hasAnyNewResults() async {
     final db = await database;
     try {
-      // Query the count of rows where the flag is 1.
       final count = Sqflite.firstIntValue(await db.query(
         'game_results_cache',
-        columns: ['COUNT(*)'], // Only need the count.
+        columns: ['COUNT(*)'],
         where: 'new_draw_flag = ?',
         whereArgs: [1],
       ));
-      bool hasNew = (count ?? 0) > 0; // True if count is greater than 0.
+      bool hasNew = (count ?? 0) > 0;
       _log.fine("Checked for any new results (flag=1): Found = $hasNew (Count: ${count ?? 0})");
       return hasNew;
     } catch (e) {
       _log.severe("Error checking for any new results: $e");
-      return false; // Return false on error.
+      return false;
     }
   }
-// --- End Utility Methods ---
-
-} // End of DatabaseHelper class
+}

--- a/lib/src/golden_ticket/game_selector_screen.dart
+++ b/lib/src/golden_ticket/game_selector_screen.dart
@@ -1,127 +1,106 @@
 import 'package:flutter/material.dart';
+import 'game_rules.dart'; // For GameRule class
+import 'database_helper.dart'; // For DatabaseHelper
 
-// Define the list of available game events (display names) that the user can select from.
-// This is currently hardcoded. In a future version, this might be loaded dynamically.
-// NOTE: Only 'Event 6/49' is currently listed.
-const List<String> gameEvents = <String>['Event 6/49'];
-
-/// A StatefulWidget that presents a screen for selecting a game event.
-/// Users choose an event from a dropdown list.
 class GameSelectorScreen extends StatefulWidget {
   const GameSelectorScreen({super.key});
-
-  // Route name used for navigation to this screen.
   static const routeName = '/game-selector';
 
   @override
   State<GameSelectorScreen> createState() => _GameSelectorScreenState();
 }
 
-/// The State class for the GameSelectorScreen widget.
-/// Manages the currently selected event.
 class _GameSelectorScreenState extends State<GameSelectorScreen> {
-  // State variable to hold the string value of the currently selected game event.
-  // It's initialized to null, meaning no selection has been made initially.
-  String? selectedEvent;
+  String? selectedGameKey;
+  late Future<List<GameRule>> _futureRules;
+
+  @override
+  void initState() {
+    super.initState();
+    _futureRules = DatabaseHelper().fetchAllGameRules();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        // Title for the screen.
-        title: const Text('Select Event'),
-      ),
-      // Center the main content.
+      appBar: AppBar(title: const Text('Select Event')),
       body: Center(
-        // Add padding around the content.
         child: Padding(
           padding: const EdgeInsets.all(16.0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center, // Center the column vertically.
-            children: [
-              // Instructional text for the user.
-              const Text(
-                'Choose the event you want to add:',
-                style: TextStyle(fontSize: 18),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 30), // Vertical spacing.
-
-              // --- Dropdown Button Section ---
-              // Wrap the DropdownButton in a Container for custom styling (border, padding).
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 4.0),
-                decoration: BoxDecoration(
-                  border: Border.all(color: Colors.grey.shade400, width: 1), // Add a border.
-                  borderRadius: BorderRadius.circular(8.0), // Rounded corners.
-                  // Optional background color:
-                  // color: Colors.grey[50],
-                ),
-                // Hide the default underline of the DropdownButton for a cleaner look.
-                child: DropdownButtonHideUnderline(
-                  child: DropdownButton<String>(
-                    // The currently selected value in the dropdown. Binds to the state variable.
-                    value: selectedEvent,
-                    // Make the dropdown button expand to fill the available width.
-                    isExpanded: true,
-                    // Text displayed when no item is selected (value is null).
-                    hint: const Text("Select a game event..."),
-                    // Style the dropdown icon.
-                    icon: const Icon(Icons.arrow_drop_down, color: Colors.deepPurple),
-                    // Shadow effect for the dropdown menu.
-                    elevation: 16,
-                    // Style for the text items within the dropdown menu.
-                    style: const TextStyle(color: Colors.deepPurple, fontSize: 16),
-                    // Callback function executed when the user selects a new item.
-                    onChanged: (String? newValue) {
-                      // Update the state variable with the newly selected value.
-                      // setState triggers a rebuild to reflect the change in the UI.
-                      setState(() {
-                        selectedEvent = newValue;
-                      });
-                      // Optional: Show a temporary message confirming the selection.
-                      // ScaffoldMessenger.of(context).showSnackBar(
-                      //   SnackBar(content: Text('Selected event: $newValue')),
-                      // );
-                    },
-                    // Generate the list of dropdown menu items from the global `gameEvents` list.
-                    items: gameEvents.map<DropdownMenuItem<String>>((String value) {
-                      // Create a DropdownMenuItem for each string in the gameEvents list.
-                      return DropdownMenuItem<String>(
-                        value: value, // The value that will be assigned to `selectedEvent` when chosen.
-                        child: Text(value), // The text displayed for this item in the dropdown.
-                      );
-                    }).toList(), // Convert the mapped iterable to a List.
+          child: FutureBuilder<List<GameRule>>(
+            future: _futureRules,
+            builder: (context, snapshot) {
+              if (snapshot.connectionState != ConnectionState.done) {
+                return const CircularProgressIndicator();
+              }
+              if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                return const Text('No games available.');
+              }
+              final rules = snapshot.data!;
+              return Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Text(
+                    'Choose the event you want to add:',
+                    style: TextStyle(fontSize: 18),
+                    textAlign: TextAlign.center,
                   ),
-                ),
-              ),
-              // --- End Dropdown Button Section ---
-
-              const SizedBox(height: 40), // More vertical spacing.
-
-              // --- Confirmation Button Section ---
-              ElevatedButton(
-                // Apply styling, ensuring a minimum button size.
-                style: ElevatedButton.styleFrom(
-                  minimumSize: const Size(200, 45),
-                  // Foreground/background colors are handled automatically based on enabled state.
-                ),
-                // The `onPressed` callback is set to null if `selectedEvent` is null,
-                // which automatically disables the button.
-                onPressed: selectedEvent == null ? null : () {
-                  // When the button is pressed (and enabled):
-                  // Pop the current screen off the navigation stack and return the
-                  // `selectedEvent` string as the result to the previous screen
-                  // (the one that called Navigator.pushNamed for this screen).
-                  Navigator.pop(context, selectedEvent);
-                },
-                child: const Text('Confirm Selection'),
-              )
-              // --- End Confirmation Button Section ---
-            ],
+                  const SizedBox(height: 30),
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 4.0),
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Colors.grey.shade400, width: 1),
+                      borderRadius: BorderRadius.circular(8.0),
+                    ),
+                    child: DropdownButtonHideUnderline(
+                      child: DropdownButton<String>(
+                        value: selectedGameKey,
+                        isExpanded: true,
+                        hint: const Text("Select a game event..."),
+                        icon: const Icon(Icons.arrow_drop_down, color: Colors.deepPurple),
+                        elevation: 16,
+                        style: const TextStyle(color: Colors.deepPurple, fontSize: 16),
+                        onChanged: (String? newValue) {
+                          setState(() {
+                            selectedGameKey = newValue;
+                          });
+                        },
+                        items: rules.map((rule) {
+                          return DropdownMenuItem<String>(
+                            value: rule.gameName,
+                            child: Text(_prettifyGameName(rule.gameName)),
+                          );
+                        }).toList(),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 40),
+                  ElevatedButton(
+                    style: ElevatedButton.styleFrom(minimumSize: const Size(200, 45)),
+                    onPressed: selectedGameKey == null ? null : () {
+                      Navigator.pop(context, selectedGameKey);
+                    },
+                    child: const Text('Confirm Selection'),
+                  )
+                ],
+              );
+            },
           ),
         ),
       ),
     );
+  }
+
+  String _prettifyGameName(String key) {
+    switch (key) {
+      case 'lotto649':
+        return "Lotto 6/49";
+      case 'LottoMax':
+        return "Lotto Max";
+      case 'DailyGrand':
+        return "Daily Grand";
+      default:
+        return key;
+    }
   }
 }

--- a/lib/src/golden_ticket/the_forge_screen.dart
+++ b/lib/src/golden_ticket/the_forge_screen.dart
@@ -20,7 +20,7 @@ import 'routes.dart'; // For Back button navigation
 /// A screen where users can manage their "Ingot Crucible" by:
 /// 1. Smelting "Ingots" (combinations) from the server.
 /// 2. Storing Ingots in a local collection.
-/// 3. Placing Ingots from the collection onto the Crucible.
+/// 3. Placing Ingots from the collection onto the 11111111111111111111111111111111111Crucible.
 /// 4. Forging the final Crucible tickets via API call.
 class TheForgeScreen extends StatefulWidget {
   const TheForgeScreen({super.key});

--- a/lib/src/golden_ticket/the_smelter.dart
+++ b/lib/src/golden_ticket/the_smelter.dart
@@ -1,0 +1,1206 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+import 'dart:math';
+import 'package:confetti/confetti.dart';
+import 'package:logging/logging.dart';
+import 'dart:async';
+import 'package:intl/intl.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+import 'ingot_crucible.dart';
+import 'logging_utils.dart';
+import 'auth/auth_state.dart';
+import 'database_helper.dart';
+import 'game_rules.dart';
+import 'routes.dart';
+
+class SmelterScreen extends StatefulWidget {
+  const SmelterScreen({super.key});
+
+  @override
+  State<SmelterScreen> createState() => _SmelterScreenState();
+}
+
+class _SmelterScreenState extends State<SmelterScreen> {
+  final _log = Logger('SmelterScreen');
+  final dbHelper = DatabaseHelper();
+
+  // Crucible/Game selection
+  List<GameRule> _availableGames = [];
+  GameRule? _selectedGameRule;
+
+  // State variables
+  bool _isLoading = true;
+  String? _errorMessage;
+  String? _targetDrawDate;
+  int? _totalCombinations;
+  int? _requestsUsed;
+  int? _requestLimit;
+  String? _archiveChecksum;
+  int _calculatedRequestsRemaining = 0;
+  DateTime? _cutoffTimeUtc;
+  bool _isPastCutoff = false;
+  Timer? _timer;
+
+  IngotCrucible? _currentCrucible;
+  List<CombinationWithId> _ingotCollection = [];
+  CombinationWithId? _selectedIngotFromCollection;
+  CombinationWithId? _selectedIngotInCrucible;
+
+  bool _isCrucibleLocked = false;
+  bool _isForging = false;
+  bool _isSmelting = false;
+
+  // Confetti controllers
+  late ConfettiController _confettiController;
+  late ConfettiController _sparksController;
+
+  bool get _interactionsDisabled =>
+      _isLoading ||
+      _isPastCutoff ||
+      _isCrucibleLocked ||
+      _isForging ||
+      _isSmelting;
+
+  @override
+  void initState() {
+    super.initState();
+    LoggingUtils.setupLogger(_log);
+    _confettiController =
+        ConfettiController(duration: const Duration(seconds: 2));
+    _sparksController =
+        ConfettiController(duration: const Duration(seconds: 1));
+    _timer = Timer.periodic(const Duration(seconds: 30), (timer) {
+      if (mounted) {
+        _updateCutoffStatus();
+      } else {
+        timer.cancel();
+      }
+    });
+    _loadAvailableGames();
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _confettiController.dispose();
+    _sparksController.dispose();
+    super.dispose();
+  }
+
+  /// Loads the games that the current user has activated in their profile.
+  Future<void> _loadAvailableGames() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+    try {
+      final authState = Provider.of<AuthState>(context, listen: false);
+      print('DEBUG: SmelterScreen userId: ${authState.userId}');
+      int? currentUserId;
+      try {
+        currentUserId = int.parse(authState.userId);
+      } catch (_) {
+        throw Exception("Invalid user ID.");
+      }
+      final games = await dbHelper.getActiveGameRulesForUser(currentUserId);
+      if (games.isEmpty) {
+        throw Exception("No active games found in your profile. Go to Profile or Account to add games.");
+      }
+      setState(() {
+        _availableGames = games;
+        _selectedGameRule = games.first;
+      });
+      await _onGameRuleChanged(_selectedGameRule!);
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+        _errorMessage = "Error loading games: ${e.toString()}";
+      });
+    }
+  }
+
+  Future<void> _onGameRuleChanged(GameRule newRule) async {
+    setState(() {
+      _isLoading = true;
+      _selectedGameRule = newRule;
+      _errorMessage = null;
+      _ingotCollection.clear();
+      _selectedIngotFromCollection = null;
+      _selectedIngotInCrucible = null;
+      _currentCrucible = null;
+      _isCrucibleLocked = false;
+      _targetDrawDate = null;
+    });
+    try {
+      final latestDrawInfo = await dbHelper.getGameDrawInfo(newRule.gameName);
+      if (latestDrawInfo == null) {
+        throw Exception("No draw info found for ${newRule.gameName}.");
+      }
+      _targetDrawDate = latestDrawInfo.drawDate;
+      await _loadGameData();
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+        _errorMessage = "Error changing crucible/game: ${e.toString()}";
+      });
+    }
+  }
+
+  Future<void> _loadGameData() async {
+    final rule = _selectedGameRule;
+    if (rule == null) return;
+    final authState = Provider.of<AuthState>(context, listen: false);
+    int? currentUserId;
+    try {
+      currentUserId = int.parse(authState.userId);
+    } catch (_) {
+      setState(() {
+        _isLoading = false;
+        _errorMessage = "Invalid user ID.";
+      });
+      return;
+    }
+    final drawDate = _targetDrawDate!;
+    try {
+      final drawInfoFuture = dbHelper.getGameDrawInfo(rule.gameName, drawDate);
+      final crucibleFuture =
+          dbHelper.getUserCrucibleForDraw(currentUserId, drawDate);
+      final ingotCollectionFuture =
+          dbHelper.getIngotCollection(currentUserId, rule.gameName, drawDate);
+
+      final results = await Future.wait(
+        [drawInfoFuture, crucibleFuture, ingotCollectionFuture],
+      );
+      final GameDrawInfo? drawInfo = results[0] as GameDrawInfo?;
+      final IngotCrucible? loadedCrucible = results[1] as IngotCrucible?;
+      _ingotCollection = results[2] as List<CombinationWithId>;
+
+      if (drawInfo == null) {
+        throw Exception("Draw info not found.");
+      }
+
+      _totalCombinations = drawInfo.totalCombinations;
+      _requestsUsed = drawInfo.userCombinationsRequested;
+      _requestLimit = drawInfo.userRequestLimit;
+      _archiveChecksum = drawInfo.archiveChecksum;
+      int limit = _requestLimit ?? 0;
+      int used = _requestsUsed ?? 0;
+      _calculatedRequestsRemaining = (limit - used) < 0 ? 0 : (limit - used);
+
+      _currentCrucible = loadedCrucible ??
+          IngotCrucible(
+            combinations: [],
+            status: 'draft',
+            submittedDate: DateTime.now(),
+            drawDate: DateTime.parse(drawDate),
+            userId: currentUserId,
+            name: "${rule.gameName} Crucible",
+          );
+      _cutoffTimeUtc = _calculateCutoffTime(drawDate, rule);
+      _updateCutoffStatus();
+      _isCrucibleLocked = (_currentCrucible?.status == 'locked' ||
+          _currentCrucible?.status == 'submitted');
+      setState(() {
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+        _errorMessage = "Error loading game data: ${e.toString()}";
+      });
+    }
+  }
+
+  DateTime? _calculateCutoffTime(String drawDateStr, GameRule? rule) {
+    if (rule == null) return null;
+    try {
+      DateTime targetDrawDay = DateTime.parse(drawDateStr);
+      List<Map<String, dynamic>> possibleDraws = [];
+      final dayMap = {
+        'Mon': 1,
+        'Tue': 2,
+        'Wed': 3,
+        'Thu': 4,
+        'Fri': 5,
+        'Sat': 6,
+        'Sun': 7
+      };
+      final scheduleParts = rule.drawSchedule.split(',');
+      for (String part in scheduleParts) {
+        final components = part.trim().split(' ');
+        if (components.length == 3) {
+          int? weekday = dayMap[components[0]];
+          final timeParts = components[1].split(':');
+          final tzId = components[2];
+          if (weekday != null && timeParts.length == 2 && tzId.contains('/')) {
+            int hour = int.parse(timeParts[0]);
+            int minute = int.parse(timeParts[1]);
+            possibleDraws.add({
+              'weekday': weekday,
+              'hour': hour,
+              'minute': minute,
+              'tzId': tzId
+            });
+          }
+        }
+      }
+      if (possibleDraws.isEmpty) return null;
+      tz.TZDateTime? foundDrawTime;
+      int targetWeekday = targetDrawDay.weekday;
+      for (var drawInfo in possibleDraws) {
+        if (drawInfo['weekday'] == targetWeekday) {
+          final location = tz.getLocation(drawInfo['tzId']);
+          final potentialDraw = tz.TZDateTime(
+              location,
+              targetDrawDay.year,
+              targetDrawDay.month,
+              targetDrawDay.day,
+              drawInfo['hour'],
+              drawInfo['minute']);
+          if (potentialDraw.year == targetDrawDay.year &&
+              potentialDraw.month == targetDrawDay.month &&
+              potentialDraw.day == targetDrawDay.day) {
+            foundDrawTime = potentialDraw;
+            break;
+          }
+        }
+      }
+      if (foundDrawTime == null) return null;
+      DateTime cutoffTime = foundDrawTime.subtract(const Duration(hours: 1));
+      return cutoffTime.toUtc();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  void _updateCutoffStatus() {
+    if (_cutoffTimeUtc != null) {
+      final nowUtc = DateTime.now().toUtc();
+      final newStatus = nowUtc.isAfter(_cutoffTimeUtc!);
+      if (newStatus != _isPastCutoff && mounted) {
+        setState(() {
+          _isPastCutoff = newStatus;
+        });
+      }
+    } else if (!_isPastCutoff && mounted) {
+      if (!_isLoading) {
+        setState(() => _isPastCutoff = true);
+      }
+    }
+  }
+
+  // ---- Business Logic from previous TheForgeScreen ----
+
+  Future<void> _smeltIngot() async {
+    if (_interactionsDisabled || _isSmelting) return;
+    if (_calculatedRequestsRemaining <= 0) {
+      _showSnackBar("Cannot smelt ingot: No smelts remaining.");
+      return;
+    }
+    if (_totalCombinations == null) {
+      _showSnackBar('Game data not loaded.');
+      return;
+    }
+    final authState = Provider.of<AuthState>(context, listen: false);
+    if (authState.authToken.isEmpty) {
+      _showSnackBar('Authentication error.');
+      return;
+    }
+
+    setState(() {
+      _isSmelting = true;
+    });
+    final url =
+        Uri.https('governance.page', '/wp-json/apigold/v1/request-combination');
+    final randomNumber = Random().nextInt(_totalCombinations!) + 1;
+    int? previousRequestsUsed = _requestsUsed;
+    try {
+      final response = await http.post(
+        url,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ${authState.authToken}',
+        },
+        body: jsonEncode({
+          'game_name': _selectedGameRule!.gameName,
+          'draw_date': _targetDrawDate,
+          'combination_number': randomNumber,
+        }),
+      );
+      if (!mounted) return;
+      if (response.statusCode == 200) {
+        final responseData = json.decode(response.body);
+        final ingotId = responseData['combination_sequence_id'];
+        final combinationNumbersRaw = responseData['combination_numbers'];
+        final int? updatedRequestsUsed =
+            responseData['user_requests_count'] as int?;
+        if (ingotId is! int) throw FormatException('Invalid Ingot ID received');
+        if (updatedRequestsUsed == null) throw FormatException('Missing updated request count from server');
+        List<int>? parsedCombinationNumbers;
+        if (combinationNumbersRaw is List && combinationNumbersRaw.isNotEmpty) {
+          parsedCombinationNumbers = combinationNumbersRaw
+              .map((e) => int.parse(e.toString()))
+              .toList();
+        } else {
+          throw FormatException('Invalid combination numbers received');
+        }
+        await dbHelper.addIngotToCollection(
+          userId: int.parse(authState.userId),
+          gameName: _selectedGameRule!.gameName,
+          drawDate: _targetDrawDate!,
+          ingotId: ingotId,
+          numbers: parsedCombinationNumbers,
+        );
+        await _updateDbRequestCount(updatedRequestsUsed);
+        if (mounted) {
+          setState(() {
+            _ingotCollection.insert(
+                0,
+                CombinationWithId(
+                    ingotId: ingotId, numbers: parsedCombinationNumbers!));
+            _requestsUsed = updatedRequestsUsed;
+            int limit = _requestLimit ?? 0;
+            _calculatedRequestsRemaining =
+                (limit - _requestsUsed!) < 0 ? 0 : (limit - _requestsUsed!);
+          });
+        }
+        _showSnackBar("Ingot #$ingotId added to collection!");
+        _sparksController.play();
+      } else {
+        String message =
+            'Failed to smelt ingot (Status: ${response.statusCode})';
+        try {
+          message = json.decode(response.body)['message'] ?? message;
+        } catch (_) {}
+        _showSnackBar(message);
+      }
+    } catch (e) {
+      _showSnackBar('Error smelting ingot: ${e.toString()}');
+      if (mounted && previousRequestsUsed != null) {
+        setState(() {
+          _requestsUsed = previousRequestsUsed;
+          int limit = _requestLimit ?? 0;
+          _calculatedRequestsRemaining =
+              (limit - _requestsUsed!) < 0 ? 0 : (limit - _requestsUsed!);
+        });
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSmelting = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _updateDbRequestCount(int newRequestCount) async {
+    if (!mounted) return;
+    try {
+      final existingInfo =
+          await dbHelper.getGameDrawInfo(_selectedGameRule!.gameName, _targetDrawDate!);
+      final infoToUpdate = GameDrawInfo(
+        gameName: _selectedGameRule!.gameName,
+        drawDate: _targetDrawDate!,
+        userCombinationsRequested: newRequestCount,
+        userRequestLimit: existingInfo?.userRequestLimit ?? _requestLimit,
+        totalCombinations: existingInfo?.totalCombinations ?? _totalCombinations,
+        archiveChecksum: existingInfo?.archiveChecksum ?? _archiveChecksum,
+      );
+      await dbHelper.upsertGameDrawInfo(infoToUpdate);
+    } catch (e) {
+      _showSnackBar("Error saving request count update.");
+    }
+  }
+
+  Future<void> _addSelectedIngotToCrucible() async {
+    if (_interactionsDisabled) {
+      _showSnackBar("Cannot modify crucible now.");
+      return;
+    }
+    if (_selectedIngotFromCollection == null) {
+      _showSnackBar("Select an ingot from your collection first.");
+      return;
+    }
+    if (_currentCrucible == null) {
+      _showSnackBar("Error: Crucible data not available.");
+      return;
+    }
+    final maxSlots = _selectedGameRule?.regularBallsDrawn ?? 6;
+    if (_currentCrucible!.combinations.length >= maxSlots) {
+      _showSnackBar("Crucible is full. Select a slot to replace.");
+      return;
+    }
+
+    final ingotToAdd = _selectedIngotFromCollection!;
+    _currentCrucible!.addCombination(ingotToAdd);
+    try {
+      await dbHelper.removeIngotFromCollection(ingotToAdd.ingotId);
+      if (mounted) {
+        setState(() {
+          _ingotCollection
+              .removeWhere((ingot) => ingot.ingotId == ingotToAdd.ingotId);
+          _selectedIngotFromCollection = null;
+        });
+        await _saveDraftCrucible();
+        _confettiController.play();
+        _showSnackBar("Ingot #${ingotToAdd.ingotId} added to crucible.");
+      }
+    } catch (e) {
+      _currentCrucible!.combinations.remove(ingotToAdd);
+      _showSnackBar("Error updating collection.");
+      if (mounted) setState(() {});
+    }
+  }
+
+  Future<void> _swapCrucibleAndCollectionIngots() async {
+    if (_interactionsDisabled) {
+      _showSnackBar("Cannot modify crucible now.");
+      return;
+    }
+    if (_selectedIngotFromCollection == null) {
+      _showSnackBar("Select an ingot from your collection to swap.");
+      return;
+    }
+    if (_selectedIngotInCrucible == null) {
+      _showSnackBar("Select a slot on the Crucible to replace.");
+      return;
+    }
+    if (_currentCrucible == null) {
+      _showSnackBar("Error: Crucible data not available.");
+      return;
+    }
+
+    final ingotFromCollection = _selectedIngotFromCollection!;
+    final ingotInCrucible = _selectedIngotInCrucible!;
+    int indexInCrucible = _currentCrucible!.combinations
+        .indexWhere((c) => c.ingotId == ingotInCrucible.ingotId);
+
+    if (indexInCrucible == -1) {
+      setState(() {
+        _selectedIngotInCrucible = null;
+      });
+      _showSnackBar("Error: Could not find the selected crucible slot.");
+      return;
+    }
+
+    setState(() {
+      _currentCrucible!.combinations[indexInCrucible] = ingotFromCollection;
+      _ingotCollection
+          .removeWhere((ingot) => ingot.ingotId == ingotFromCollection.ingotId);
+      _ingotCollection.insert(0, ingotInCrucible);
+      _selectedIngotFromCollection = null;
+      _selectedIngotInCrucible = null;
+    });
+
+    try {
+      await dbHelper.removeIngotFromCollection(ingotFromCollection.ingotId);
+      await dbHelper.addIngotToCollection(
+          userId: _currentCrucible!.userId!,
+          gameName: _selectedGameRule!.gameName,
+          drawDate: _targetDrawDate!,
+          ingotId: ingotInCrucible.ingotId,
+          numbers: ingotInCrucible.numbers);
+      await _saveDraftCrucible();
+      _confettiController.play();
+      _showSnackBar(
+          "Ingot #${ingotFromCollection.ingotId} placed in crucible, Ingot #${ingotInCrucible.ingotId} returned to collection.");
+    } catch (e) {
+      setState(() {
+        _currentCrucible!.combinations[indexInCrucible] = ingotInCrucible;
+        _ingotCollection.removeWhere(
+            (ingot) => ingot.ingotId == ingotInCrucible.ingotId);
+        _ingotCollection.insert(0, ingotFromCollection);
+      });
+      _showSnackBar("Error updating collection during swap.");
+    }
+  }
+
+  Future<void> _saveDraftCrucible(
+      {bool showSnackbar = true, bool bypassLoadingCheck = false}) async {
+    if (_currentCrucible == null || (!bypassLoadingCheck && _isLoading)) return;
+    if (_isCrucibleLocked) return;
+
+    _currentCrucible!.status = 'draft';
+    _currentCrucible!.submittedDate = DateTime.now();
+
+    try {
+      int resultId = await dbHelper.insertIngotCrucible(_currentCrucible!);
+      if (resultId > 0) {
+        if (mounted && _currentCrucible!.id == null) {
+          _currentCrucible!.id = resultId;
+        }
+        if (showSnackbar) _showSnackBar('Draft saved.');
+      } else {
+        if (showSnackbar) _showSnackBar('Failed to save draft.');
+      }
+    } catch (e) {
+      if (showSnackbar) _showSnackBar('Error saving draft.');
+    }
+  }
+
+  Future<void> _forgeTickets() async {
+    if (_interactionsDisabled || _isForging) return;
+    if (_currentCrucible == null) return;
+    final maxSlots = _selectedGameRule?.regularBallsDrawn ?? 6;
+    if (_currentCrucible!.combinations.length < maxSlots) {
+      _showSnackBar("Please fill all $maxSlots crucible slots before forging.");
+      return;
+    }
+    final bool? confirmed = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Confirm Forge'),
+          content: const SingleChildScrollView(
+            child: ListBody(
+              children: <Widget>[
+                Text('Are you sure you want to forge these tickets?'),
+                SizedBox(height: 8),
+                Text(
+                    'This action is permanent for this draw and cannot be undone.',
+                    style: TextStyle(fontWeight: FontWeight.bold)),
+              ],
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+                child: const Text('Cancel'),
+                onPressed: () => Navigator.of(context).pop(false)),
+            FilledButton(
+                child: const Text('Forge Tickets'),
+                onPressed: () => Navigator.of(context).pop(true)),
+          ],
+        );
+      },
+    );
+    if (confirmed != true) return;
+
+    setState(() {
+      _isForging = true;
+    });
+
+    _currentCrucible!.status = 'submitted';
+    _currentCrucible!.submittedDate = DateTime.now();
+    try {
+      await _saveDraftCrucible(showSnackbar: false, bypassLoadingCheck: true);
+    } catch (_) {
+      _showSnackBar("Error saving crucible status locally.");
+      if (mounted) {
+        setState(() {
+          _isForging = false;
+        });
+      }
+      return;
+    }
+
+    final authState = Provider.of<AuthState>(context, listen: false);
+    final List<int> ingotIdsToSend =
+        _currentCrucible!.combinations.map((c) => c.ingotId).toList();
+    final requestBody = jsonEncode({
+      'user_id': _currentCrucible!.userId,
+      'game_name': _selectedGameRule!.gameName,
+      'draw_date': _targetDrawDate,
+      'play_card_id': _currentCrucible!.id,
+      'ingot_ids': ingotIdsToSend,
+    });
+
+    try {
+      final url = Uri.https('governance.page', '/wp-json/apigold/v1/submit-playcard');
+      final response = await http
+          .post(
+            url,
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer ${authState.authToken}',
+            },
+            body: requestBody,
+          )
+          .timeout(const Duration(seconds: 20));
+      if (!mounted) return;
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        bool success = false;
+        String message = "Tickets Forged Successfully!";
+        try {
+          final responseData = json.decode(response.body);
+          if (responseData['status'] == 'success' ||
+              responseData['status'] == 'playcard_submitted') {
+            success = true;
+            message = responseData['message'] ?? message;
+          } else {
+            message = responseData['message'] ?? "Server indicated submission failed.";
+          }
+        } catch (_) {
+          success = true;
+        }
+        if (success) {
+          _showSnackBar(message);
+          if (mounted) {
+            setState(() {
+              _isCrucibleLocked = true;
+            });
+            try {
+              int userId = int.parse(authState.userId);
+              await dbHelper.clearIngotCollectionForDraw(
+                  userId, _selectedGameRule!.gameName, _targetDrawDate!);
+              setState(() {
+                _ingotCollection = [];
+                _selectedIngotFromCollection = null;
+              });
+            } catch (_) {}
+          }
+        } else {
+          _showSnackBar(message);
+          _currentCrucible!.status = 'draft';
+          await _saveDraftCrucible(showSnackbar: false, bypassLoadingCheck: true);
+          if (mounted) {
+            setState(() => _isCrucibleLocked = false);
+          }
+        }
+      } else {
+        String errorMessage = "Failed to forge tickets.";
+        try {
+          final responseData = json.decode(response.body);
+          errorMessage =
+              responseData['message'] ?? "Server error ${response.statusCode}";
+        } catch (_) {
+          errorMessage =
+              "Server error ${response.statusCode}. Could not parse response.";
+        }
+        _showSnackBar(errorMessage);
+        _currentCrucible!.status = 'draft';
+        await _saveDraftCrucible(showSnackbar: false, bypassLoadingCheck: true);
+        if (mounted) {
+          setState(() {
+            _isCrucibleLocked = false;
+          });
+        }
+      }
+    } on TimeoutException catch (_) {
+      _showSnackBar("Network timeout forging tickets. Please try again.");
+      _currentCrucible!.status = 'draft';
+      await _saveDraftCrucible(showSnackbar: false, bypassLoadingCheck: true);
+      if (mounted) {
+        setState(() {
+          _isCrucibleLocked = false;
+        });
+      }
+    } catch (_) {
+      _showSnackBar("Network error forging tickets.");
+      _currentCrucible!.status = 'draft';
+      await _saveDraftCrucible(showSnackbar: false, bypassLoadingCheck: true);
+      if (mounted) {
+        setState(() {
+          _isCrucibleLocked = false;
+        });
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isForging = false;
+        });
+      }
+    }
+  }
+
+  void _showSnackBar(String text) {
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(text), duration: const Duration(seconds: 2)),
+      );
+    }
+  }
+
+  String _formatDuration(Duration duration) {
+    if (duration.isNegative) return "Cutoff Passed";
+    int days = duration.inDays;
+    int hours = duration.inHours % 24;
+    int minutes = duration.inMinutes % 60;
+    List<String> parts = [];
+    if (days > 0) parts.add('${days}d');
+    if (hours > 0) parts.add('${hours}h');
+    if (minutes >= 0 || parts.isEmpty) parts.add('${minutes}m');
+    if (parts.isEmpty) return "< 1m";
+    return parts.join(' ');
+  }
+
+  String _truncateChecksum(String checksum, {int length = 16}) {
+    if (checksum.length <= length) {
+      return checksum;
+    }
+    int endIndex = length < checksum.length ? length : checksum.length;
+    return '${checksum.substring(0, endIndex)}...';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cutoffTime = _cutoffTimeUtc;
+    String timeRemainingStr = "Loading...";
+    if (!_isLoading) {
+      if (cutoffTime != null) {
+        final now = DateTime.now().toUtc();
+        timeRemainingStr = now.isBefore(cutoffTime)
+            ? "Cutoff in ${_formatDuration(cutoffTime.difference(now))}"
+            : "Cutoff Passed";
+      } else if (_targetDrawDate != null && _targetDrawDate!.isNotEmpty) {
+        timeRemainingStr = "Cutoff time unknown";
+      } else {
+        timeRemainingStr = "Draw info unavailable";
+      }
+    }
+
+    String crucibleStatusText = "";
+    Color crucibleStatusColor = Colors.grey;
+    IconData crucibleStatusIcon = Icons.info_outline;
+    int currentSlots = _currentCrucible?.combinations.length ?? 0;
+    int maxSlots = _selectedGameRule?.regularBallsDrawn ?? 6;
+    bool isCrucibleFull =
+        !_isLoading && _currentCrucible != null && currentSlots >= maxSlots;
+
+    if (!_isLoading && _currentCrucible != null) {
+      if (_isCrucibleLocked) {
+        crucibleStatusText = "Crucible Locked";
+        crucibleStatusColor = Colors.red[700]!;
+        crucibleStatusIcon = Icons.lock_outline;
+      } else if (_isPastCutoff) {
+        crucibleStatusText = "Cutoff Passed";
+        crucibleStatusColor = Colors.red[700]!;
+        crucibleStatusIcon = Icons.timer_off_outlined;
+      } else if (currentSlots == 0) {
+        crucibleStatusText = "Crucible Empty";
+        crucibleStatusColor = Colors.orange[700]!;
+        crucibleStatusIcon = Icons.warning_amber_rounded;
+      } else if (currentSlots < maxSlots) {
+        crucibleStatusText =
+            "Crucible Partially Forged ($currentSlots / $maxSlots slots)";
+        crucibleStatusColor = Colors.blue[700]!;
+        crucibleStatusIcon = Icons.info_outline;
+      } else {
+        crucibleStatusText =
+            "Crucible Full ($currentSlots / $maxSlots slots) - Ready to Forge";
+        crucibleStatusColor = Colors.green[700]!;
+        crucibleStatusIcon = Icons.check_circle_outline;
+      }
+    } else if (_isLoading) {
+      crucibleStatusText = "Loading crucible status...";
+    } else {
+      crucibleStatusText = "Crucible status unavailable.";
+    }
+
+    final bool canSmelt =
+        !_interactionsDisabled && _calculatedRequestsRemaining > 0;
+    final bool canReplace = !_interactionsDisabled &&
+        _selectedIngotInCrucible != null &&
+        _selectedIngotFromCollection != null;
+    final bool canAdd = !_interactionsDisabled &&
+        _selectedIngotFromCollection != null &&
+        !isCrucibleFull;
+    final bool canForge = !_interactionsDisabled && isCrucibleFull;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('The Smelter', style: TextStyle(fontWeight: FontWeight.bold)),
+        centerTitle: true,
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _errorMessage != null
+              ? Center(child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(_errorMessage!, style: const TextStyle(color: Colors.red)),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: () {
+                          setState(() {
+                            _isLoading = true;
+                            _errorMessage = null;
+                          });
+                          _loadAvailableGames();
+                        },
+                        child: const Text('Retry Load'),
+                      ),
+                    ],
+                  ),
+                ))
+              : SingleChildScrollView(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // --- Crucible (Game) Selector ---
+                      Card(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                          child: DropdownButtonHideUnderline(
+                            child: DropdownButton<GameRule>(
+                              value: _selectedGameRule,
+                              isExpanded: true,
+                              onChanged: (game) {
+                                if (game != null) _onGameRuleChanged(game);
+                              },
+                              items: _availableGames.map<DropdownMenuItem<GameRule>>((GameRule rule) {
+                                return DropdownMenuItem<GameRule>(
+                                  value: rule,
+                                  child: Text(rule.gameName),
+                                );
+                              }).toList(),
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                      // --- Status Info ---
+                      Card(
+                        elevation: 1,
+                        margin: const EdgeInsets.only(bottom: 12),
+                        child: Padding(
+                          padding: const EdgeInsets.all(12.0),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Game: ${_selectedGameRule?.gameName ?? "..."}',
+                                style: Theme.of(context).textTheme.headlineSmall,
+                              ),
+                              Text(
+                                'Draw Date: ${_targetDrawDate != null ? DateFormat('EEEE, MMMM d, yyyy').format(DateTime.parse(_targetDrawDate!)) : "..."}',
+                                style: Theme.of(context).textTheme.titleMedium,
+                              ),
+                              Text(
+                                timeRemainingStr,
+                                style: TextStyle(
+                                  color: _isPastCutoff
+                                      ? Colors.red
+                                      : Colors.green[700],
+                                  fontStyle: FontStyle.italic,
+                                ),
+                              ),
+                              Text(
+                                'Smelts Remaining: $_calculatedRequestsRemaining / ${_requestLimit ?? "?"}',
+                                style: Theme.of(context).textTheme.bodyMedium,
+                              ),
+                              if (_archiveChecksum != null &&
+                                  _archiveChecksum!.isNotEmpty)
+                                Padding(
+                                  padding: const EdgeInsets.only(top: 4.0),
+                                  child: Text(
+                                    'Ingot Pool Checksum: ${_truncateChecksum(_archiveChecksum!)}',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .bodySmall
+                                        ?.copyWith(color: Colors.grey[600]),
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
+                      ),
+                      // --- Smelt Button ---
+                      ElevatedButton.icon(
+                        icon: _isSmelting
+                            ? Container(
+                                width: 20,
+                                height: 20,
+                                padding: const EdgeInsets.all(2.0),
+                                child: const CircularProgressIndicator(
+                                  strokeWidth: 3,
+                                  color: Colors.black54,
+                                ),
+                              )
+                            : const Icon(Icons.whatshot),
+                        label: Text(_isSmelting ? 'Smelting...' : 'Smelt Ingot'),
+                        onPressed: canSmelt ? _smeltIngot : null,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: canSmelt
+                              ? Colors.orange[300]
+                              : Theme.of(context).disabledColor,
+                          foregroundColor:
+                              canSmelt ? Colors.black : Colors.white70,
+                          minimumSize: const Size(double.infinity, 44),
+                        ),
+                      ),
+                      const SizedBox(height: 10),
+                      Text(
+                        "Ingot Collection (${_ingotCollection.length})",
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      Container(
+                        height: 100,
+                        decoration: BoxDecoration(
+                          border: Border.all(color: Colors.grey.shade300),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: _ingotCollection.isEmpty
+                            ? Center(
+                                child: Text(
+                                  "Smelt ingots to collect them here.",
+                                  style: TextStyle(color: Colors.grey[600]),
+                                ),
+                              )
+                            : ListView.builder(
+                                itemCount: _ingotCollection.length,
+                                itemBuilder: (context, index) {
+                                  final ingot = _ingotCollection[index];
+                                  bool isSelected =
+                                      _selectedIngotFromCollection?.ingotId ==
+                                          ingot.ingotId;
+                                  return ListTile(
+                                    dense: true,
+                                    title: Text('Ingot #${ingot.ingotId}'),
+                                    subtitle: Text(ingot.numbers.join(', ')),
+                                    selected: isSelected,
+                                    selectedTileColor: Colors.blue[50],
+                                    onTap: _interactionsDisabled
+                                        ? null
+                                        : () {
+                                            setState(() {
+                                              _selectedIngotFromCollection =
+                                                  isSelected ? null : ingot;
+                                            });
+                                          },
+                                    trailing: isSelected
+                                        ? const Icon(Icons.check_circle,
+                                            color: Colors.blue)
+                                        : null,
+                                  );
+                                },
+                              ),
+                      ),
+                      const SizedBox(height: 10),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          ElevatedButton.icon(
+                            icon:
+                                const Icon(Icons.add_box_outlined, size: 18),
+                            label: const Text("Add to Crucible"),
+                            onPressed: canAdd ? _addSelectedIngotToCrucible : null,
+                            style: ElevatedButton.styleFrom(
+                                backgroundColor: Colors.green[100]),
+                          ),
+                          ElevatedButton.icon(
+                            icon: const Icon(Icons.swap_horiz, size: 18),
+                            label: const Text("Replace Slot"),
+                            onPressed: canReplace
+                                ? _swapCrucibleAndCollectionIngots
+                                : null,
+                            style: ElevatedButton.styleFrom(
+                                backgroundColor: Colors.orange[100]),
+                          ),
+                        ],
+                      ),
+                      const Divider(height: 20, thickness: 1),
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 8.0),
+                        child: Row(
+                          children: [
+                            Icon(crucibleStatusIcon,
+                                color: crucibleStatusColor, size: 18),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                crucibleStatusText,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .titleMedium
+                                    ?.copyWith(color: crucibleStatusColor),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      // Crucible Slots Grid
+                      SizedBox(
+                        height: 120,
+                        child: (_currentCrucible?.combinations.isEmpty ?? true)
+                            ? Container(
+                                alignment: Alignment.center,
+                                decoration: BoxDecoration(
+                                  border: Border.all(color: Colors.grey.shade300),
+                                  borderRadius: BorderRadius.circular(8),
+                                  color: Colors.grey[50],
+                                ),
+                                child: Text(
+                                  'Add ingots from your collection to the crucible.',
+                                  style: TextStyle(
+                                      color: Colors.grey[600],
+                                      fontStyle: FontStyle.italic),
+                                ),
+                              )
+                            : GridView.builder(
+                                gridDelegate:
+                                    const SliverGridDelegateWithFixedCrossAxisCount(
+                                  crossAxisCount: 3,
+                                  childAspectRatio: 2.5 / 1.2,
+                                  mainAxisSpacing: 8,
+                                  crossAxisSpacing: 8,
+                                ),
+                                itemCount: maxSlots,
+                                itemBuilder: (context, index) {
+                                  final combination = (index < currentSlots)
+                                      ? _currentCrucible!.combinations[index]
+                                      : null;
+                                  bool isSelected =
+                                      _selectedIngotInCrucible?.ingotId ==
+                                          combination?.ingotId;
+                                  bool isEmptySlot = combination == null;
+                                  return GestureDetector(
+                                    onTap: _interactionsDisabled
+                                        ? null
+                                        : () {
+                                            setState(() {
+                                              _selectedIngotInCrucible =
+                                                  (isSelected || isEmptySlot)
+                                                      ? null
+                                                      : combination;
+                                            });
+                                          },
+                                    child: Container(
+                                      padding: const EdgeInsets.symmetric(
+                                          vertical: 4, horizontal: 6),
+                                      decoration: BoxDecoration(
+                                        border: Border.all(
+                                          color: isSelected
+                                              ? Colors.orange.shade300
+                                              : (isEmptySlot
+                                                  ? Colors.grey.shade300
+                                                  : Colors.black54),
+                                          width: isSelected ? 2 : 1,
+                                          style: BorderStyle.solid,
+                                        ),
+                                        borderRadius: BorderRadius.circular(8),
+                                        boxShadow: isSelected
+                                            ? [
+                                                BoxShadow(
+                                                  color: Colors.orange
+                                                      .withOpacity(0.3),
+                                                  spreadRadius: 1,
+                                                  blurRadius: 3,
+                                                ),
+                                              ]
+                                            : [],
+                                        backgroundBlendMode: _interactionsDisabled
+                                            ? BlendMode.saturation
+                                            : null,
+                                        color: _interactionsDisabled
+                                            ? Colors.grey[300]
+                                            : (isSelected
+                                                ? Colors.orange[100]
+                                                : (isEmptySlot
+                                                    ? Colors.grey[100]
+                                                    : Colors.amber[100])),
+                                      ),
+                                      child: isEmptySlot
+                                          ? Center(
+                                              child: Text(
+                                                "Slot ${index + 1}",
+                                                style: TextStyle(
+                                                    color: Colors.grey[500],
+                                                    fontSize: 12),
+                                              ),
+                                            )
+                                          : Column(
+                                              mainAxisAlignment:
+                                                  MainAxisAlignment.center,
+                                              children: [
+                                                Text(
+                                                  combination.numbers.join(' '),
+                                                  style: TextStyle(
+                                                    color: _interactionsDisabled
+                                                        ? Colors.grey[600]
+                                                        : Colors.black,
+                                                    fontWeight: FontWeight.bold,
+                                                    fontSize: 14,
+                                                  ),
+                                                  textAlign: TextAlign.center,
+                                                  maxLines: 1,
+                                                  overflow: TextOverflow.ellipsis,
+                                                ),
+                                                Text(
+                                                  'ID# ${combination.ingotId}',
+                                                  style: TextStyle(
+                                                    color: _interactionsDisabled
+                                                        ? Colors.grey[500]
+                                                        : Colors.black54,
+                                                    fontSize: 10,
+                                                  ),
+                                                  textAlign: TextAlign.center,
+                                                  maxLines: 1,
+                                                  overflow: TextOverflow.ellipsis,
+                                                ),
+                                              ],
+                                            ),
+                                    ),
+                                  );
+                                },
+                              ),
+                      ),
+                      const SizedBox(height: 8),
+                      if (canForge)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8.0),
+                          child: ElevatedButton.icon(
+                            icon: _isForging
+                                ? Container(
+                                    width: 20,
+                                    height: 20,
+                                    padding: const EdgeInsets.all(2.0),
+                                    child: const CircularProgressIndicator(
+                                      strokeWidth: 3,
+                                      color: Colors.white,
+                                    ),
+                                  )
+                                : const Icon(Icons.gavel),
+                            label:
+                                Text(_isForging ? 'Forging...' : 'Forge Tickets'),
+                            onPressed: _isForging ? null : _forgeTickets,
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor:
+                                  Theme.of(context).colorScheme.primary,
+                              foregroundColor:
+                                  Theme.of(context).colorScheme.onPrimary,
+                              minimumSize: const Size(double.infinity, 44),
+                            ),
+                          ),
+                        ),
+                      TextButton(
+                        onPressed: () => Navigator.pop(context),
+                        child: const Text('Back'),
+                      ),
+                      Align(
+                        alignment: Alignment.topCenter,
+                        child: ConfettiWidget(
+                          confettiController: _confettiController,
+                          blastDirectionality: BlastDirectionality.explosive,
+                          shouldLoop: false,
+                          numberOfParticles: 15,
+                          gravity: 0.1,
+                        ),
+                      ),
+                      Align(
+                        alignment: Alignment.center,
+                        child: ConfettiWidget(
+                          confettiController: _sparksController,
+                          blastDirectionality: BlastDirectionality.explosive,
+                          emissionFrequency: 0.05,
+                          numberOfParticles: 8,
+                          gravity: 0.05,
+                          colors: const [
+                            Colors.yellow,
+                            Colors.orange,
+                            Colors.amber
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 3.0.1-beta.1+3
+version: 3.1.1-beta.1+5
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
- Deleted `the_forge_screen.dart` and merged all business logic, UI, and interaction flows into `the_smelter.dart`.
- The Smelter screen now fully replaces The Forge, handling all ticket selection, ingot smelting, crucible management, and submission.
- All legacy code and references to The Forge removed.
- Refactored game/draw date workflow to always use the latest available draw for the selected game from the database, not just today's date. This resolves longstanding "Draw info not found" errors and ensures UI stays in sync with backend/game state.
- Added a helper to DatabaseHelper: `getLatestGameDrawInfo(gameName)` for reliable draw retrieval.
- Updated all draw, ingot, and crucible queries and mutations to reference the current authoritative draw date, preventing data mismatch and race conditions.
- Improved user experience by adding clearer error messages, robust async handling, and future-proofing for additional games.
- Updated in-code documentation and improved maintainability for future changes.

BREAKING CHANGE: The Forge screen is fully removed. All related workflows now occur in The Smelter.

Version: 3.1.0-beta.1+5